### PR TITLE
Ability to manually configure base details

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -210,7 +210,7 @@ class Ziggy implements JsonSerializable
 
         $this->baseUrl = Str::finish($this->baseProtocol, '://')
             . rtrim($this->baseDomain, '/')
-            . ($this->basePort ? ':' . ltrim($this->basePort) : '')
+            . ($this->basePort ? ':' . ltrim($this->basePort, ':') : '')
             . '/';
     }
 }

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -201,8 +201,8 @@ class Ziggy implements JsonSerializable
         $this->basePort = $settings->get('port');
 
         $this->baseUrl = Str::finish($this->baseProtocol, '://')
-            .Str::of($this->baseDomain)->rtrim('/')
-            .($this->basePort ? Str::of($this->basePort)->prepend(':') : '')
-            .'/';
+            . Str::of($this->baseDomain)->rtrim('/')
+            . ($this->basePort ? Str::of($this->basePort)->prepend(':') : '')
+            . '/';
     }
 }

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -183,13 +183,21 @@ class Ziggy implements JsonSerializable
         ];
 
         $settings = Collection::make($defaults)
+            // First, we attempt to parse our App's default using Laravel's URL helper.
             ->merge(parse_url(Str::finish($defaults['url'], '/')) ?? [])
+            // Next, we overload these defaults with any Ziggy-configured settings.
             ->merge(config()->get('ziggy', []))
+            // If the user configured a URL in Ziggy, it takes precedence over
+            // all the other user-configured settings. We'll try to parse
+            // this URL, and overload the defaults with it again.
             ->when(config()->has('ziggy.url'), function (Collection $settings) {
                 return $settings
                     ->merge(['port' => null])
                     ->merge(parse_url(Str::finish($settings->get('url'), '/')) ?? []);
             })
+            // Finally, we'll accept the given URL (if any), which takes the
+            // highest priority. We'll attempt parsing it and overwrite
+            // the defaults with it one last time.
             ->when($url, function (Collection $settings) use ($url) {
                 return $settings
                     ->merge(['port' => null])

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -209,8 +209,8 @@ class Ziggy implements JsonSerializable
         $this->basePort = $settings->get('port');
 
         $this->baseUrl = Str::finish($this->baseProtocol, '://')
-            . Str::of($this->baseDomain)->rtrim('/')
-            . ($this->basePort ? Str::of($this->basePort)->prepend(':') : '')
+            . rtrim($this->baseDomain, '/')
+            . ($this->basePort ? ':' . ltrim($this->basePort) : '')
             . '/';
     }
 }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -586,4 +586,57 @@ class ZiggyTest extends TestCase
         $response->assertSuccessful();
         $this->assertSame((new Ziggy)->toJson(), $response->getContent());
     }
+
+    /** @test */
+    public function can_configure_base_details()
+    {
+        config(['ziggy' => [
+            'scheme' => 'https',
+            'host' => 'example.com',
+            'port' => '8080',
+        ]]);
+
+        $ziggy = (new Ziggy)->toArray();
+
+        $this->assertEquals('https://example.com:8080/', $ziggy['baseUrl']);
+        $this->assertEquals('https', $ziggy['baseProtocol']);
+        $this->assertEquals('example.com', $ziggy['baseDomain']);
+        $this->assertEquals(8080, $ziggy['basePort']);
+    }
+
+    /** @test */
+    public function can_configure_an_url_that_takes_precedence_over_other_configured_base_details()
+    {
+        config(['ziggy' => [
+            'url' => 'https://example.com/',
+            'scheme' => 'ssh',
+            'host' => 'tighten.co',
+            'port' => '1337',
+        ]]);
+
+        $ziggy = (new Ziggy)->toArray();
+
+        $this->assertEquals('https://example.com/', $ziggy['baseUrl']);
+        $this->assertEquals('https', $ziggy['baseProtocol']);
+        $this->assertEquals('example.com', $ziggy['baseDomain']);
+        $this->assertNull($ziggy['basePort']);
+    }
+
+    /** @test */
+    public function a_given_url_always_takes_precedence_over_configured_base_details()
+    {
+        config(['ziggy' => [
+            'url' => 'ftp://example.com/',
+            'scheme' => 'ssh',
+            'host' => 'tighten.co',
+            'port' => '1337',
+        ]]);
+
+        $ziggy = (new Ziggy(false, 'https://laravel.com/'))->toArray();
+
+        $this->assertEquals('https://laravel.com/', $ziggy['baseUrl']);
+        $this->assertEquals('https', $ziggy['baseProtocol']);
+        $this->assertEquals('laravel.com', $ziggy['baseDomain']);
+        $this->assertNull($ziggy['basePort']);
+    }
 }


### PR DESCRIPTION
In situations where an app is (for example) behind a load balancer with SSL termination, Ziggy is unable to properly parse the environment details required for a correctly working front-end, which causes other front-end libraries (like Vue or Axios) to make invalid requests.

Here's an example:
![image](https://user-images.githubusercontent.com/1752195/89557285-dacb7800-d812-11ea-95cd-9ecce522d175.png)

This PR solves this by changing the way these settings are gathered, and is backwards-compatible with existing behaviour. Configurable are the following options:
- `scheme` (http, https, ssh, ftp ...)
- `host` (example.com)
- `port`(443, 80, 1234 ...)

Additionally or alternatively, a user can also provide an `url` option, which **overwrites most if not all of those configurable options**, depending on what parts of the URL were provided. For instance, if you provide `//example.com`, only the `host` will be overwritten (as only it can be parsed)