### PR TITLE
Use APP_URL instead of url() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Breaking changes are marked with ⚠️.
 - ⚠️ Rename all `whitelist` and `blacklist` functionality to `only` and `except` ([#300](https://github.com/tighten/ziggy/pull/300))
 - Use Jest instead of Mocha for JS tests ([#309](https://github.com/tighten/ziggy/pull/309))
 - Use [microbundle](https://github.com/developit/microbundle) instead of Webpack to build and distribute Ziggy ([#312](https://github.com/tighten/ziggy/pull/312))
+- ⚠️ Default Ziggy's `baseUrl` to the value of the `APP_URL` environment variable instead of `url('/')` ([#334](https://github.com/tighten/ziggy/pull/334))
 
 **Removed**
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -21,7 +21,7 @@ class Ziggy implements JsonSerializable
     {
         $this->group = $group;
 
-        $this->baseUrl = Str::finish($url ?? config('app.url'), '/');
+        $this->baseUrl = Str::finish($url ?? config('app.url', url('/')), '/');
 
         tap(parse_url($this->baseUrl), function ($url) {
             $this->baseProtocol = $url['scheme'] ?? 'http';

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -21,7 +21,7 @@ class Ziggy implements JsonSerializable
     {
         $this->group = $group;
 
-        $this->baseUrl = Str::finish($url ?? url('/'), '/');
+        $this->baseUrl = Str::finish($url ?? config('app.url'), '/');
 
         tap(parse_url($this->baseUrl), function ($url) {
             $this->baseProtocol = $url['scheme'] ?? 'http';


### PR DESCRIPTION
Closes #313 by defaulting Ziggy's base URL to the value of the `APP_URL` environment variable (via `config('app.url')`). `url('/')` remains the fallback value if `APP_URL` isn't set, but it uses the URL of the _request_ which isn't always what the frontend needs.

My only concern with this is situations where `APP_URL` isn't correct either. Not sure how common that is. See #329.