### PR TITLE
Remove baseProtocol and baseDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Breaking changes are marked with ⚠️.
     - `name`, `absolute`, `ziggy`, `urlBuilder`, `template`, `urlParams`, `queryParams`, and `hydrated`
     - `normalizeParams()`, `hydrateUrl()`, `matchUrl()`, `constructQuery()`, `extractParams()`, `parse()`, and `trimParam()`
 - ⚠️ Remove the `UrlBuilder` class ([#330](https://github.com/tighten/ziggy/pull/330)):
+- ⚠️ Remove the `baseDomain` and `baseProtocol` properties on the Ziggy config object ([#337](https://github.com/tighten/ziggy/pull/337)):
 
 **Fixed**
 

--- a/README.md
+++ b/README.md
@@ -263,8 +263,6 @@ Route::get('/login', function () {
 var Ziggy = {
     namedRoutes: {"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"login":{"uri":"login","methods":["GET","HEAD"],"domain":null}},
     baseUrl: 'http://ziggy.test/',
-    baseProtocol: 'http',
-    baseDomain: 'ziggy.test',
     basePort: false
 };
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -10,9 +10,7 @@ use ReflectionMethod;
 
 class Ziggy implements JsonSerializable
 {
-    protected $baseDomain;
     protected $basePort;
-    protected $baseProtocol;
     protected $baseUrl;
     protected $group;
     protected $routes;
@@ -22,12 +20,7 @@ class Ziggy implements JsonSerializable
         $this->group = $group;
 
         $this->baseUrl = rtrim($url ?? config('app.url', url('/')), '/');
-
-        tap(parse_url($this->baseUrl), function ($url) {
-            $this->baseProtocol = $url['scheme'] ?? 'http';
-            $this->baseDomain = $url['host'] ?? '';
-            $this->basePort = $url['port'] ?? null;
-        });
+        $this->basePort = parse_url($this->baseUrl)['port'] ?? null;
 
         $this->routes = $this->nameKeyedRoutes();
     }
@@ -136,8 +129,6 @@ class Ziggy implements JsonSerializable
     {
         return [
             'baseUrl' => $this->baseUrl,
-            'baseProtocol' => $this->baseProtocol,
-            'baseDomain' => $this->baseDomain,
             'basePort' => $this->basePort,
             'defaultParameters' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -28,7 +28,7 @@ class Route {
         // If  we're building just a path there's no origin, otherwise: if this route has a
         // domain configured we construct the origin with that, if not we use the app URL
         const origin = !this.config.absolute ? '' : this.definition.domain
-            ? `${this.config.baseProtocol}://${this.definition.domain}${this.config.basePort ? `:${this.config.basePort}` : ''}`
+            ? `${this.config.baseUrl.match(/^\w+:\/\//)[0]}${this.definition.domain}${this.config.basePort ? `:${this.config.basePort}` : ''}`
             : this.config.baseUrl;
 
         return `${origin}/${this.definition.uri}`;

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -392,8 +392,6 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'baseUrl' => 'http://ziggy.dev',
-            'baseProtocol' => 'http',
-            'baseDomain' => 'ziggy.dev',
             'basePort' => null,
             'defaultParameters' => [],
             'namedRoutes' => [
@@ -439,8 +437,6 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'baseUrl' => 'http://ziggy.dev',
-            'baseProtocol' => 'http',
-            'baseDomain' => 'ziggy.dev',
             'basePort' => null,
             'defaultParameters' => [],
             'namedRoutes' => [
@@ -453,7 +449,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":{"locale":"en"},"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/example.org","basePort":null,"defaultParameters":{"locale":"en"},"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -9,8 +9,6 @@ const defaultWindow = {
 
 const defaultZiggy = {
     baseUrl: 'https://ziggy.dev',
-    baseProtocol: 'https',
-    baseDomain: 'ziggy.dev',
     basePort: null,
     defaultParameters: { locale: 'en' },
     namedRoutes: {
@@ -353,7 +351,6 @@ describe('route()', () => {
 
     test('can generate a URL with a port', () => {
         global.Ziggy.baseUrl = 'https://ziggy.dev:81';
-        global.Ziggy.baseDomain = 'ziggy.dev';
         global.Ziggy.basePort = 81;
 
         // route with no parameters
@@ -401,8 +398,6 @@ describe('route()', () => {
     test('can accept a custom Ziggy configuration object', () => {
         const config = {
             baseUrl: 'http://notYourAverage.dev',
-            baseProtocol: 'http',
-            baseDomain: 'notYourAverage.dev',
             basePort: false,
             defaultParameters: { locale: 'en' },
             namedRoutes: {
@@ -520,8 +515,6 @@ describe('current()', () => {
 
         const config = {
             baseUrl: 'https://ziggy.dev',
-            baseProtocol: 'https',
-            baseDomain: 'ziggy.dev',
             basePort: false,
             namedRoutes: {
                 'events.index': {


### PR DESCRIPTION
This PR removes the `baseProtocol` and `baseDomain` properties on the Ziggy configuration object. `baseDomain` actually wasn't used anywhere, and `baseProtocol` was inferred from `baseUrl`, so now we just use that directly.

Closes #333.