### PR TITLE
Remove "base" and other prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,8 @@ assignees: ''
 
 <!-- Include ALL of the information below: -->
 
-- **Laravel version**: 
-- **Ziggy version**: 
+- **Laravel version**:
+- **Ziggy version**:
 
 **Related routes**:
 
@@ -30,9 +30,9 @@ assignees: ''
 Route::get('/', 'HomeController')->name('home');
 ```
 
-**`Ziggy.namedRoutes`**:
+**`Ziggy.routes`**:
 
-<!-- In your browser console/devtools, run `Ziggy.namedRoutes` and paste the result here. E.g.: -->
+<!-- In your browser console/devtools, run `Ziggy.routes` and paste the result here. E.g.: -->
 
 ```js
 {

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,8 @@ assignees: ''
 
 <!-- Include ALL of the information below: -->
 
-- **Laravel version**:
-- **Ziggy version**:
+- **Laravel version**: 
+- **Ziggy version**: 
 
 **Related routes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Breaking changes are marked with ⚠️.
 - Use [microbundle](https://github.com/developit/microbundle) instead of Webpack to build and distribute Ziggy ([#312](https://github.com/tighten/ziggy/pull/312))
 - ⚠️ Default Ziggy's `baseUrl` to the value of the `APP_URL` environment variable instead of `url('/')` ([#334](https://github.com/tighten/ziggy/pull/334))
 - ⚠️ Allow getting the route name with `current()` when the current URL has a query string ([#330](https://github.com/tighten/ziggy/pull/330))
+- ⚠️ Rename `namedRoutes` → `routes`, `defaultParameters` → `defaults`, `baseUrl` → `url`, and `basePort` → `port` ([#338](https://github.com/tighten/ziggy/pull/338))
 
 **Deprecated**
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ var Ziggy = {
     url: 'http://ziggy.test/',
     baseProtocol: 'http',
     baseDomain: 'ziggy.test',
-    basePort: false
+    port: null
 };
 
 export {

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ var Ziggy = {
     url: 'http://ziggy.test/',
     baseProtocol: 'http',
     baseDomain: 'ziggy.test',
-    port: null
+    port: null,
 };
 
 export {

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See the [Laravel documentation on default route parameter values](https://larave
 Default values work out of the box for Laravel versions >= 5.5.29, for previous versions you will need to set the default parameters by including this code somewhere in the same page as Ziggy's `@routes` Blade directive.
 
 ```js
-Ziggy.defaultParameters = {
+Ziggy.defaults = {
     // example
     locale: 'en',
 };

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Route::get('/login', function () {
 
 var Ziggy = {
     routes: {"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"login":{"uri":"login","methods":["GET","HEAD"],"domain":null}},
-    baseUrl: 'http://ziggy.test/',
+    url: 'http://ziggy.test/',
     baseProtocol: 'http',
     baseDomain: 'ziggy.test',
     basePort: false

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Note that you still have to generate your routes file with `php artisan ziggy:ge
 
 ## Usage
 
-This package uses the `@routes` directive to inject a JavaScript object containing all of your application's routes, keyed by their names. This collection is available at `Ziggy.namedRoutes`.
+This package uses the `@routes` directive to inject a JavaScript object containing all of your application's routes, keyed by their names. This collection is available at `Ziggy.routes`.
 
 The package also creates an optional `route()` JavaScript helper that functions like Laravel's PHP `route()` helper, which can be used to retrieve URLs by name and (optionally) parameters.
 
@@ -261,7 +261,7 @@ Route::get('/login', function () {
 // ziggy.js
 
 var Ziggy = {
-    namedRoutes: {"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"login":{"uri":"login","methods":["GET","HEAD"],"domain":null}},
+    routes: {"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"login":{"uri":"login","methods":["GET","HEAD"],"domain":null}},
     baseUrl: 'http://ziggy.test/',
     baseProtocol: 'http',
     baseDomain: 'ziggy.test',

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -36,7 +36,7 @@ HTML;
         var routes = {$json};
 
         for (var name in routes) {
-            Ziggy.namedRoutes[name] = routes[name];
+            Ziggy.routes[name] = routes[name];
         }
     })();
 </script>

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -12,7 +12,7 @@ class BladeRouteGenerator
         $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (static::$generated) {
-            return $this->generateMergeJavascript(json_encode($payload->toArray()['namedRoutes']), $nonce);
+            return $this->generateMergeJavascript(json_encode($payload->toArray()['routes']), $nonce);
         }
 
         $routeFunction = $this->getRouteFunction();

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -43,8 +43,8 @@ class CommandRouteGenerator extends Command
 var Ziggy = {$payload};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (var name in window.Ziggy.namedRoutes) {
-        Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
+    for (var name in window.Ziggy.routes) {
+        Ziggy.routes[name] = window.Ziggy.routes[name];
     }
 }
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -142,7 +142,7 @@ class Ziggy implements JsonSerializable
             'defaultParameters' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],
-            'namedRoutes' => $this->applyFilters($this->group)->toArray(),
+            'routes' => $this->applyFilters($this->group)->toArray(),
         ];
     }
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -13,7 +13,7 @@ class Ziggy implements JsonSerializable
     protected $baseDomain;
     protected $basePort;
     protected $baseProtocol;
-    protected $baseUrl;
+    protected $url;
     protected $group;
     protected $routes;
 
@@ -21,9 +21,9 @@ class Ziggy implements JsonSerializable
     {
         $this->group = $group;
 
-        $this->baseUrl = rtrim($url ?? config('app.url', url('/')), '/');
+        $this->url = rtrim($url ?? config('app.url', url('/')), '/');
 
-        tap(parse_url($this->baseUrl), function ($url) {
+        tap(parse_url($this->url), function ($url) {
             $this->baseProtocol = $url['scheme'] ?? 'http';
             $this->baseDomain = $url['host'] ?? '';
             $this->basePort = $url['port'] ?? null;
@@ -135,7 +135,7 @@ class Ziggy implements JsonSerializable
     public function toArray(): array
     {
         return [
-            'baseUrl' => $this->baseUrl,
+            'url' => $this->url,
             'baseProtocol' => $this->baseProtocol,
             'baseDomain' => $this->baseDomain,
             'basePort' => $this->basePort,

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -11,7 +11,7 @@ use ReflectionMethod;
 class Ziggy implements JsonSerializable
 {
     protected $baseDomain;
-    protected $basePort;
+    protected $port;
     protected $baseProtocol;
     protected $url;
     protected $group;
@@ -26,7 +26,7 @@ class Ziggy implements JsonSerializable
         tap(parse_url($this->url), function ($url) {
             $this->baseProtocol = $url['scheme'] ?? 'http';
             $this->baseDomain = $url['host'] ?? '';
-            $this->basePort = $url['port'] ?? null;
+            $this->port = $url['port'] ?? null;
         });
 
         $this->routes = $this->nameKeyedRoutes();
@@ -138,7 +138,7 @@ class Ziggy implements JsonSerializable
             'url' => $this->url,
             'baseProtocol' => $this->baseProtocol,
             'baseDomain' => $this->baseDomain,
-            'basePort' => $this->basePort,
+            'port' => $this->port,
             'defaults' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -139,7 +139,7 @@ class Ziggy implements JsonSerializable
             'baseProtocol' => $this->baseProtocol,
             'baseDomain' => $this->baseDomain,
             'basePort' => $this->basePort,
-            'defaultParameters' => method_exists(app('url'), 'getDefaultParameters')
+            'defaults' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],
             'routes' => $this->applyFilters($this->group)->toArray(),

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -231,7 +231,7 @@ class Router extends String {
         params = ['string', 'number'].includes(typeof params) ? [params] : params;
 
         // Separate segments with and without defaults, and fill in the default values
-        const segments = route.parameterSegments.filter(({ name }) => !this._config.defaultParameters[name]);
+        const segments = route.parameterSegments.filter(({ name }) => !this._config.defaults[name]);
 
         if (Array.isArray(params)) {
             // If the parameters are an array they have to be in order, so we can transform them into
@@ -266,8 +266,8 @@ class Router extends String {
      * @return {Object} Default route parameters.
      */
     _defaults(route) {
-        return route.parameterSegments.filter(({ name }) => this._config.defaultParameters[name])
-            .reduce((result, { name }, i) => ({ ...result, [name]: this._config.defaultParameters[name] }), {});
+        return route.parameterSegments.filter(({ name }) => this._config.defaults[name])
+            .reduce((result, { name }, i) => ({ ...result, [name]: this._config.defaults[name] }), {});
     }
 
     /**

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -28,7 +28,7 @@ class Route {
         // If  we're building just a path there's no origin, otherwise: if this route has a
         // domain configured we construct the origin with that, if not we use the app URL
         const origin = !this.config.absolute ? '' : this.definition.domain
-            ? `${this.config.baseProtocol}://${this.definition.domain}${this.config.basePort ? `:${this.config.basePort}` : ''}`
+            ? `${this.config.baseProtocol}://${this.definition.domain}${this.config.port ? `:${this.config.port}` : ''}`
             : this.config.url;
 
         return `${origin}/${this.definition.uri}`;

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -104,11 +104,11 @@ class Router extends String {
         this._config = config ?? Ziggy ?? globalThis?.Ziggy;
 
         if (name) {
-            if (!this._config.namedRoutes[name]) {
+            if (!this._config.routes[name]) {
                 throw new Error(`Ziggy error: route '${name}' is not in the route list.`);
             }
 
-            this._route = new Route(name, this._config.namedRoutes[name], { ...this._config, absolute });
+            this._route = new Route(name, this._config.routes[name], { ...this._config, absolute });
             this._params = this._parse(params);
         }
     }
@@ -156,7 +156,7 @@ class Router extends String {
         const url = window.location.host + window.location.pathname;
 
         // Find the first route that matches the current URL
-        const [current, route] = Object.entries(this._config.namedRoutes).find(
+        const [current, route] = Object.entries(this._config.routes).find(
             ([_, route]) => new Route(name, route, this._config).matchesUrl(url)
         );
 
@@ -188,7 +188,7 @@ class Router extends String {
      * @return {Object}
      */
     get params() {
-        return this._dehydrate(this._config.namedRoutes[this.current()]);
+        return this._dehydrate(this._config.routes[this.current()]);
     }
 
     /**
@@ -198,7 +198,7 @@ class Router extends String {
      * @return {Boolean}
      */
     has(name) {
-        return Object.keys(this._config.namedRoutes).includes(name);
+        return Object.keys(this._config.routes).includes(name);
     }
 
     /**

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -29,7 +29,7 @@ class Route {
         // domain configured we construct the origin with that, if not we use the app URL
         const origin = !this.config.absolute ? '' : this.definition.domain
             ? `${this.config.baseProtocol}://${this.definition.domain}${this.config.basePort ? `:${this.config.basePort}` : ''}`
-            : this.config.baseUrl;
+            : this.config.url;
 
         return `${origin}/${this.definition.uri}`;
     }
@@ -313,7 +313,7 @@ class Router extends String {
     _dehydrate(route) {
         let pathname = window.location.pathname
             // If this Laravel app is in a subdirectory, trim the subdirectory from the path
-            .replace(this._config.baseUrl.replace(/^\w*:\/\/[^/]+/, ''), '')
+            .replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '')
             .replace(/^\/+/, '');
 
         // Given part of a valid 'hydrated' URL containing all its parameter values,

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -13,7 +13,7 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $generator = app(BladeRouteGenerator::class);
 
-        $this->assertStringContainsString('"namedRoutes":[]', $generator->generate());
+        $this->assertStringContainsString('"routes":[]', $generator->generate());
     }
 
     /** @test */
@@ -30,11 +30,11 @@ class BladeRouteGeneratorTest extends TestCase
         $output = (new BladeRouteGenerator)->generate();
         $ziggy = json_decode(Str::after(Str::before($output, ";\n\n"), ' = '), true);
 
-        $this->assertCount(4, $ziggy['namedRoutes']);
-        $this->assertArrayHasKey('posts.index', $ziggy['namedRoutes']);
-        $this->assertArrayHasKey('posts.show', $ziggy['namedRoutes']);
-        $this->assertArrayHasKey('posts.store', $ziggy['namedRoutes']);
-        $this->assertArrayHasKey('postComments.index', $ziggy['namedRoutes']);
+        $this->assertCount(4, $ziggy['routes']);
+        $this->assertArrayHasKey('posts.index', $ziggy['routes']);
+        $this->assertArrayHasKey('posts.show', $ziggy['routes']);
+        $this->assertArrayHasKey('posts.store', $ziggy['routes']);
+        $this->assertArrayHasKey('postComments.index', $ziggy['routes']);
     }
 
     /** @test */

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -160,7 +160,7 @@ class RouteModelBindingTest extends TestCase
                     'tag' => 'slug',
                 ],
             ],
-        ], (new Ziggy)->toArray()['namedRoutes']);
+        ], (new Ziggy)->toArray()['routes']);
     }
 
     /** @test */
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","port":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -394,7 +394,7 @@ class ZiggyTest extends TestCase
             'url' => 'http://ziggy.dev',
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
-            'basePort' => null,
+            'port' => null,
             'defaults' => [],
             'routes' => [
                 'home' => [
@@ -441,7 +441,7 @@ class ZiggyTest extends TestCase
             'url' => 'http://ziggy.dev',
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
-            'basePort' => null,
+            'port' => null,
             'defaults' => [],
             'routes' => [
                 'postComments.index' => [
@@ -453,7 +453,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected['routes']);
 
-        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","port":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -391,7 +391,7 @@ class ZiggyTest extends TestCase
         $ziggy = new Ziggy;
 
         $expected = [
-            'baseUrl' => 'http://ziggy.dev',
+            'url' => 'http://ziggy.dev',
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
@@ -438,7 +438,7 @@ class ZiggyTest extends TestCase
         ]]);
 
         $expected = [
-            'baseUrl' => 'http://ziggy.dev',
+            'url' => 'http://ziggy.dev',
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
@@ -453,7 +453,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected['routes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -95,7 +95,7 @@ class ZiggyTest extends TestCase
         config(['ziggy' => [
             'only' => ['posts.s*', 'home'],
         ]]);
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -121,7 +121,7 @@ class ZiggyTest extends TestCase
         config(['ziggy' => [
             'except' => ['posts.s*', 'home', 'admin.*'],
         ]]);
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'posts.index' => [
@@ -146,7 +146,7 @@ class ZiggyTest extends TestCase
             'except' => ['posts.s*'],
             'only' => ['home'],
         ]]);
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -188,7 +188,7 @@ class ZiggyTest extends TestCase
                 'authors' => ['home', 'posts.*'],
             ],
         ]]);
-        $routes = (new Ziggy('authors'))->toArray()['namedRoutes'];
+        $routes = (new Ziggy('authors'))->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -216,7 +216,7 @@ class ZiggyTest extends TestCase
     public function can_ignore_passed_group_not_set_in_config()
     {
         // The 'authors' group doesn't exist
-        $routes = (new Ziggy('authors'))->toArray()['namedRoutes'];
+        $routes = (new Ziggy('authors'))->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -256,7 +256,7 @@ class ZiggyTest extends TestCase
         config(['ziggy' => [
             'middleware' => true,
         ]]);
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -298,7 +298,7 @@ class ZiggyTest extends TestCase
         config(['ziggy' => [
             'middleware' => ['auth'],
         ]]);
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -341,7 +341,7 @@ class ZiggyTest extends TestCase
         app('router')->get('/users', $this->noop())->name('users.index');
 
         app('router')->getRoutes()->refreshNameLookups();
-        $routes = (new Ziggy)->toArray()['namedRoutes'];
+        $routes = (new Ziggy)->toArray()['routes'];
 
         $expected = [
             'home' => [
@@ -396,7 +396,7 @@ class ZiggyTest extends TestCase
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
             'defaultParameters' => [],
-            'namedRoutes' => [
+            'routes' => [
                 'home' => [
                     'uri' => 'home',
                     'methods' => ['GET', 'HEAD'],
@@ -424,7 +424,7 @@ class ZiggyTest extends TestCase
             ],
         ];
 
-        $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
+        $this->addPostCommentsRouteWithBindings($expected['routes']);
 
         $this->assertSame($expected, $ziggy->toArray());
         $this->assertSame($expected, $ziggy->jsonSerialize());
@@ -443,7 +443,7 @@ class ZiggyTest extends TestCase
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
             'defaultParameters' => [],
-            'namedRoutes' => [
+            'routes' => [
                 'postComments.index' => [
                     'uri' => 'posts/{post}/comments',
                     'methods' => ['GET', 'HEAD'],
@@ -451,9 +451,9 @@ class ZiggyTest extends TestCase
             ],
         ];
 
-        $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
+        $this->addPostCommentsRouteWithBindings($expected['routes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -395,7 +395,7 @@ class ZiggyTest extends TestCase
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
-            'defaultParameters' => [],
+            'defaults' => [],
             'routes' => [
                 'home' => [
                     'uri' => 'home',
@@ -442,7 +442,7 @@ class ZiggyTest extends TestCase
             'baseProtocol' => 'http',
             'baseDomain' => 'ziggy.dev',
             'basePort' => null,
-            'defaultParameters' => [],
+            'defaults' => [],
             'routes' => [
                 'postComments.index' => [
                     'uri' => 'posts/{post}/comments',
@@ -453,7 +453,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected['routes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","port":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,8 +1,8 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (var name in window.Ziggy.namedRoutes) {
-        Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
+    for (var name in window.Ziggy.routes) {
+        Ziggy.routes[name] = window.Ziggy.routes[name];
     }
 }
 

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,8 +1,8 @@
-var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":{"locale":"en"},"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (var name in window.Ziggy.namedRoutes) {
-        Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
+    for (var name in window.Ziggy.routes) {
+        Ziggy.routes[name] = window.Ziggy.routes[name];
     }
 }
 

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,4 +1,4 @@
-var Ziggy = {"url":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","port":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/example.org","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,8 +1,8 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (var name in window.Ziggy.namedRoutes) {
-        Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
+    for (var name in window.Ziggy.routes) {
+        Ziggy.routes[name] = window.Ziggy.routes[name];
     }
 }
 

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+var Ziggy = {"url":"http:\/\/ziggy.dev","baseProtocol":"http","baseDomain":"ziggy.dev","port":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.routes) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -8,7 +8,7 @@ const defaultWindow = {
 };
 
 const defaultZiggy = {
-    baseUrl: 'https://ziggy.dev',
+    url: 'https://ziggy.dev',
     baseProtocol: 'https',
     baseDomain: 'ziggy.dev',
     basePort: null,
@@ -287,7 +287,7 @@ describe('route()', () => {
     });
 
     test('can generate a URL for an app installed in a subfolder', () => {
-        global.Ziggy.baseUrl = 'https://ziggy.dev/subfolder';
+        global.Ziggy.url = 'https://ziggy.dev/subfolder';
 
         equal(
             route('postComments.show', [1, { uuid: 'correct-horse-etc-etc' }]),
@@ -352,7 +352,7 @@ describe('route()', () => {
     });
 
     test('can generate a URL with a port', () => {
-        global.Ziggy.baseUrl = 'https://ziggy.dev:81';
+        global.Ziggy.url = 'https://ziggy.dev:81';
         global.Ziggy.baseDomain = 'ziggy.dev';
         global.Ziggy.basePort = 81;
 
@@ -363,13 +363,13 @@ describe('route()', () => {
     });
 
     test('can handle trailing path segments in the base URL', () => {
-        global.Ziggy.baseUrl = 'https://test.thing/ab/cd';
+        global.Ziggy.url = 'https://test.thing/ab/cd';
 
         equal(route('events.venues.index', 1), 'https://test.thing/ab/cd/events/1/venues');
     });
 
     test('can URL-encode named parameters', () => {
-        global.Ziggy.baseUrl = 'https://test.thing/ab/cd';
+        global.Ziggy.url = 'https://test.thing/ab/cd';
 
         equal(
             route('events.venues.index', { event: 'Fun&Games' }),
@@ -400,7 +400,7 @@ describe('route()', () => {
 
     test('can accept a custom Ziggy configuration object', () => {
         const config = {
-            baseUrl: 'http://notYourAverage.dev',
+            url: 'http://notYourAverage.dev',
             baseProtocol: 'http',
             baseDomain: 'notYourAverage.dev',
             basePort: false,
@@ -420,7 +420,7 @@ describe('route()', () => {
     });
 
     test('can extract parameters for an app installed in a subfolder', () => {
-        global.Ziggy.baseUrl = 'https://ziggy.dev/subfolder';
+        global.Ziggy.url = 'https://ziggy.dev/subfolder';
 
         global.window.location.href = 'https://ziggy.dev/subfolder/ph/en/products/4';
         global.window.location.host = 'ziggy.dev';
@@ -430,7 +430,7 @@ describe('route()', () => {
     });
 
     test('can extract parameters for an app installed in nested subfolders', () => {
-        global.Ziggy.baseUrl = 'https://ziggy.dev/nested/subfolder';
+        global.Ziggy.url = 'https://ziggy.dev/nested/subfolder';
 
         global.window.location.href = 'https://ziggy.dev/nested/subfolder/ph/en/products/4';
         global.window.location.host = 'ziggy.dev';
@@ -519,7 +519,7 @@ describe('current()', () => {
         global.window.location.pathname = '/events/';
 
         const config = {
-            baseUrl: 'https://ziggy.dev',
+            url: 'https://ziggy.dev',
             baseProtocol: 'https',
             baseDomain: 'ziggy.dev',
             basePort: false,
@@ -570,7 +570,7 @@ describe('current()', () => {
     });
 
     test('can check the current route name on a route with optional parameters in the middle of the URI', () => {
-        global.Ziggy.baseUrl = 'https://ziggy.dev/subfolder';
+        global.Ziggy.url = 'https://ziggy.dev/subfolder';
 
         // Missing the optional 'language' parameter (e.g. subfolder/ph/en/products...)
         global.window.location.href = 'https://ziggy.dev/subfolder/ph/products/4';

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -12,7 +12,7 @@ const defaultZiggy = {
     baseProtocol: 'https',
     baseDomain: 'ziggy.dev',
     basePort: null,
-    defaultParameters: { locale: 'en' },
+    defaults: { locale: 'en' },
     routes: {
         'home': {
             uri: '/',
@@ -197,7 +197,7 @@ describe('route()', () => {
     });
 
     test('can error if a required parameter with a default has no default value', () => {
-        global.Ziggy.defaultParameters = {};
+        global.Ziggy.defaults = {};
 
         assert.throws(
             () => route('translatePosts.index').url(),
@@ -404,7 +404,7 @@ describe('route()', () => {
             baseProtocol: 'http',
             baseDomain: 'notYourAverage.dev',
             basePort: false,
-            defaultParameters: { locale: 'en' },
+            defaults: { locale: 'en' },
             routes: {
                 'tightenDev.packages.index': {
                     uri: 'tightenDev/{dev}/packages',

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -13,7 +13,7 @@ const defaultZiggy = {
     baseDomain: 'ziggy.dev',
     basePort: null,
     defaultParameters: { locale: 'en' },
-    namedRoutes: {
+    routes: {
         'home': {
             uri: '/',
             methods: ['GET', 'HEAD'],
@@ -405,7 +405,7 @@ describe('route()', () => {
             baseDomain: 'notYourAverage.dev',
             basePort: false,
             defaultParameters: { locale: 'en' },
-            namedRoutes: {
+            routes: {
                 'tightenDev.packages.index': {
                     uri: 'tightenDev/{dev}/packages',
                     methods: ['GET', 'HEAD'],
@@ -523,7 +523,7 @@ describe('current()', () => {
             baseProtocol: 'https',
             baseDomain: 'ziggy.dev',
             basePort: false,
-            namedRoutes: {
+            routes: {
                 'events.index': {
                     uri: 'events',
                     methods: ['GET', 'HEAD'],

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -11,7 +11,7 @@ const defaultZiggy = {
     url: 'https://ziggy.dev',
     baseProtocol: 'https',
     baseDomain: 'ziggy.dev',
-    basePort: null,
+    port: null,
     defaults: { locale: 'en' },
     routes: {
         'home': {
@@ -354,7 +354,7 @@ describe('route()', () => {
     test('can generate a URL with a port', () => {
         global.Ziggy.url = 'https://ziggy.dev:81';
         global.Ziggy.baseDomain = 'ziggy.dev';
-        global.Ziggy.basePort = 81;
+        global.Ziggy.port = 81;
 
         // route with no parameters
         equal(route('posts.index'), 'https://ziggy.dev:81/posts');
@@ -403,7 +403,7 @@ describe('route()', () => {
             url: 'http://notYourAverage.dev',
             baseProtocol: 'http',
             baseDomain: 'notYourAverage.dev',
-            basePort: false,
+            port: null,
             defaults: { locale: 'en' },
             routes: {
                 'tightenDev.packages.index': {
@@ -522,7 +522,7 @@ describe('current()', () => {
             url: 'https://ziggy.dev',
             baseProtocol: 'https',
             baseDomain: 'ziggy.dev',
-            basePort: false,
+            port: null,
             routes: {
                 'events.index': {
                     uri: 'events',


### PR DESCRIPTION
This PR renames:

- `namedRoutes` → `routes`
- `defaultParameters` → `defaults`
- `baseUrl` → `url`
- `basePort` → `port`

Shouldn't have much of an effect as they're mostly used internally, and where people are using them it's a straightforward change. I left out `baseProtocol` and `baseDomain` in anticipation of them being removed in #337.