### PR TITLE
Make internal PHP functionality private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Breaking changes are marked with ⚠️.
 - Use [microbundle](https://github.com/developit/microbundle) instead of Webpack to build and distribute Ziggy ([#312](https://github.com/tighten/ziggy/pull/312))
 - ⚠️ Default Ziggy's `baseUrl` to the value of the `APP_URL` environment variable instead of `url('/')` ([#334](https://github.com/tighten/ziggy/pull/334))
 - ⚠️ Allow getting the route name with `current()` when the current URL has a query string ([#330](https://github.com/tighten/ziggy/pull/330))
+- ⚠️ Make the `filter()` method on the `Ziggy` class return an instance of that class instead of a collection of routes ([#341](https://github.com/tighten/ziggy/pull/341))
+- ⚠️ Make the `nameKeyedRoutes()`, `resolveBindings()`, `applyFilters()`, and `group()` methods on the `Ziggy` class, and the `generate()` method on the `CommandRouteGenerator` class, private ([#341](https://github.com/tighten/ziggy/pull/341))
 
 **Deprecated**
 
@@ -40,6 +42,7 @@ Breaking changes are marked with ⚠️.
     - `name`, `absolute`, `ziggy`, `urlBuilder`, `template`, `urlParams`, `queryParams`, and `hydrated`
     - `normalizeParams()`, `hydrateUrl()`, `matchUrl()`, `constructQuery()`, `extractParams()`, `parse()`, and `trimParam()`
 - ⚠️ Remove the `UrlBuilder` class ([#330](https://github.com/tighten/ziggy/pull/330)):
+- ⚠️ Remove the `appendRouteToList()`, `isListedAs()`, `except()`, and `only()` methods from the `Ziggy` class ([#341](https://github.com/tighten/ziggy/pull/341))
 
 **Fixed**
 

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -35,7 +35,7 @@ class CommandRouteGenerator extends Command
         $this->info('File generated!');
     }
 
-    public function generate($group = false)
+    private function generate($group = false)
     {
         $payload = (new Ziggy($group, url($this->option('url'))))->toJson();
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -99,7 +99,7 @@ class Ziggy implements JsonSerializable
     /**
      * Get a list of the application's named routes, keyed by their names.
      */
-    protected function nameKeyedRoutes()
+    private function nameKeyedRoutes()
     {
         [$fallbacks, $routes] = collect(app('router')->getRoutes()->getRoutesByName())
             ->partition(function ($route) {
@@ -159,7 +159,7 @@ class Ziggy implements JsonSerializable
     /**
      * Resolve route key names for any route parameters using Eloquent route model binding.
      */
-    protected function resolveBindings(array $routes): array
+    private function resolveBindings(array $routes): array
     {
         $scopedBindings = method_exists(head($routes), 'bindingFields');
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -32,7 +32,7 @@ class Ziggy implements JsonSerializable
         $this->routes = $this->nameKeyedRoutes();
     }
 
-    public function applyFilters($group)
+    private function applyFilters($group)
     {
         if ($group) {
             return $this->group($group);
@@ -44,11 +44,11 @@ class Ziggy implements JsonSerializable
         }
 
         if (config()->has('ziggy.except')) {
-            return $this->filter(config('ziggy.except'), false);
+            return $this->filter(config('ziggy.except'), false)->routes;
         }
 
         if (config()->has('ziggy.only')) {
-            return $this->filter(config('ziggy.only'));
+            return $this->filter(config('ziggy.only'))->routes;
         }
 
         return $this->routes;
@@ -57,7 +57,7 @@ class Ziggy implements JsonSerializable
     /**
      * Filter routes by group.
      */
-    public function group($group)
+    private function group($group)
     {
         if (is_array($group)) {
             $filters = [];
@@ -66,11 +66,11 @@ class Ziggy implements JsonSerializable
                 $filters = array_merge($filters, config("ziggy.groups.{$groupName}"));
             }
 
-            return $this->filter($filters, true);
+            return $this->filter($filters, true)->routes;
         }
 
         if (config()->has("ziggy.groups.{$group}")) {
-            return $this->filter(config("ziggy.groups.{$group}"), true);
+            return $this->filter(config("ziggy.groups.{$group}"), true)->routes;
         }
 
         return $this->routes;
@@ -79,11 +79,13 @@ class Ziggy implements JsonSerializable
     /**
      * Filter routes by name using the given patterns.
      */
-    public function filter($filters = [], $include = true)
+    public function filter($filters = [], $include = true): self
     {
-        return $this->routes->filter(function ($route, $name) use ($filters, $include) {
+        $this->routes = $this->routes->filter(function ($route, $name) use ($filters, $include) {
             return Str::is(Arr::wrap($filters), $name) ? $include : ! $include;
         });
+
+        return $this;
     }
 
     /**

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -44,11 +44,11 @@ class Ziggy implements JsonSerializable
         }
 
         if (config()->has('ziggy.except')) {
-            return $this->except();
+            return $this->filter(config('ziggy.except'), false);
         }
 
         if (config()->has('ziggy.only')) {
-            return $this->only();
+            return $this->filter(config('ziggy.only'));
         }
 
         return $this->routes;
@@ -74,16 +74,6 @@ class Ziggy implements JsonSerializable
         }
 
         return $this->routes;
-    }
-
-    public function except()
-    {
-        return $this->filter(config('ziggy.except'), false);
-    }
-
-    public function only()
-    {
-        return $this->filter(config('ziggy.only'));
     }
 
     /**

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -110,12 +110,6 @@ class Ziggy implements JsonSerializable
 
         return $routes->merge($fallbacks)
             ->map(function ($route) use ($bindings) {
-                if ($this->isListedAs($route, 'except')) {
-                    $this->appendRouteToList($route->getName(), 'except');
-                } elseif ($this->isListedAs($route, 'only')) {
-                    $this->appendRouteToList($route->getName(), 'only');
-                }
-
                 return collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain())
                     ->put('bindings', $bindings[$route->getName()] ?? [])
@@ -160,23 +154,6 @@ class Ziggy implements JsonSerializable
     public function toJson(int $options = 0): string
     {
         return json_encode($this->jsonSerialize(), $options);
-    }
-
-    /**
-     * Add the given route name to the current list of routes.
-     */
-    protected function appendRouteToList($name, $list)
-    {
-        config()->push("ziggy.{$list}", $name);
-    }
-
-    /**
-     * Check if the given route name is present in the given list.
-     */
-    protected function isListedAs($route, $list)
-    {
-        return (isset($route->listedAs) && $route->listedAs === $list)
-            || Arr::get($route->getAction(), 'listed_as', null) === $list;
     }
 
     /**

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -52,7 +52,7 @@ class RouteModelBindingTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, (new Ziggy)->filter('users')->toArray());
+        $this->assertSame($expected, (new Ziggy)->filter('users')->toArray()['namedRoutes']);
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class RouteModelBindingTest extends TestCase
                 'uri' => 'tokens/{token}',
                 'methods' => ['GET', 'HEAD'],
             ],
-        ], (new Ziggy)->filter(['tokens'])->toArray());
+        ], (new Ziggy)->filter(['tokens'])->toArray()['namedRoutes']);
     }
 
     /** @test */
@@ -79,7 +79,7 @@ class RouteModelBindingTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, (new Ziggy)->filter('users.numbers')->toArray());
+        $this->assertSame($expected, (new Ziggy)->filter('users.numbers')->toArray()['namedRoutes']);
     }
 
     /** @test */
@@ -107,7 +107,7 @@ class RouteModelBindingTest extends TestCase
                     'tag' => 'slug',
                 ],
             ],
-        ], (new Ziggy)->filter('posts*')->toArray());
+        ], (new Ziggy)->filter('posts*')->toArray()['namedRoutes']);
     }
 
     /** @test */

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -52,7 +52,7 @@ class RouteModelBindingTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, (new Ziggy)->filter('users')->toArray()['namedRoutes']);
+        $this->assertSame($expected, (new Ziggy)->filter('users')->toArray()['routes']);
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class RouteModelBindingTest extends TestCase
                 'uri' => 'tokens/{token}',
                 'methods' => ['GET', 'HEAD'],
             ],
-        ], (new Ziggy)->filter(['tokens'])->toArray()['namedRoutes']);
+        ], (new Ziggy)->filter(['tokens'])->toArray()['routes']);
     }
 
     /** @test */
@@ -79,7 +79,7 @@ class RouteModelBindingTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, (new Ziggy)->filter('users.numbers')->toArray()['namedRoutes']);
+        $this->assertSame($expected, (new Ziggy)->filter('users.numbers')->toArray()['routes']);
     }
 
     /** @test */
@@ -107,7 +107,7 @@ class RouteModelBindingTest extends TestCase
                     'tag' => 'slug',
                 ],
             ],
-        ], (new Ziggy)->filter('posts*')->toArray()['namedRoutes']);
+        ], (new Ziggy)->filter('posts*')->toArray()['routes']);
     }
 
     /** @test */

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -64,7 +64,7 @@ class ZiggyTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $routes->toArray()['namedRoutes']);
+        $this->assertSame($expected, $routes->toArray()['routes']);
     }
 
     /** @test */
@@ -86,7 +86,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected);
 
-        $this->assertSame($expected, $routes->toArray()['namedRoutes']);
+        $this->assertSame($expected, $routes->toArray()['routes']);
     }
 
     /** @test */

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -28,7 +28,7 @@ class ZiggyTest extends TestCase
     }
 
     /**
-     * If running Laravel 7 or higher, the 'postComments.show' route.
+     * If running Laravel 7 or higher, add the 'postComments.show' route.
      */
     protected function addPostCommentsRouteWithBindings(array &$routes): void
     {

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -64,7 +64,7 @@ class ZiggyTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $routes->toArray());
+        $this->assertSame($expected, $routes->toArray()['namedRoutes']);
     }
 
     /** @test */
@@ -86,7 +86,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected);
 
-        $this->assertSame($expected, $routes->toArray());
+        $this->assertSame($expected, $routes->toArray()['namedRoutes']);
     }
 
     /** @test */


### PR DESCRIPTION
This PR removes some methods and makes a few others private in Ziggy's PHP API. These methods were either for internal use or provided no real functionality of their own.

**Notable changes**

- The `filter()` method on the `Ziggy` class is now 'fluent' and returns an instance of `Ziggy` instead of a collection of routes.

**Other changes**

- The `nameKeyedRoutes()` and `resolveBindings()` methods on the `Ziggy` class, which are for internal use, are now private.
- The `generate()` method on the `CommandRouteGenerator` is now private.
- The `applyFilters()` and `group()` methods on the `Ziggy` class are now private. This might seem like a significant change, but it isn't. Both of these methods returned an array of Ziggy-formatted route definitions, which isn't particularly useful on its own, but more importantly, they were both redundant—Ziggy already uses these methods internally to filter its routes, so calling `group()` or `applyFilters()` directly has the same effect as configuring or passing the same options before instantiating a Ziggy object. The easiest way to understand this is to look at the changes to the tests in this PR: all of the data returned by `applyFilters()` and `group()` was already available in the `namedRoutes` key of the array that Ziggy returns.

**Cleanup**

- Removed the `appendRouteToList()` and `isListedAs()` methods, and code referencing them. These were both unused since the `Router` Facade macro was removed in #306.
- Removed the `except()` and `only()` methods that didn't return anything and were already being called automatically when retrieving Ziggy's config. This functionality was inlined into the `applyFilters()` method.