### PR TITLE
Fix "merge" Javascript output of Blade directive

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -8,11 +8,11 @@ class BladeRouteGenerator
 
     public function generate($group = false, $nonce = false)
     {
-        $payload = (new Ziggy($group))->toJson();
+        $payload = new Ziggy($group);
         $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (static::$generated) {
-            return $this->generateMergeJavascript($payload, $nonce);
+            return $this->generateMergeJavascript(json_encode($payload->toArray()['namedRoutes']), $nonce);
         }
 
         $routeFunction = $this->getRouteFunction();
@@ -21,7 +21,7 @@ class BladeRouteGenerator
 
         return <<<HTML
 <script type="text/javascript"{$nonce}>
-    var Ziggy = {$payload};
+    var Ziggy = {$payload->toJson()};
 
     $routeFunction
 </script>

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -38,6 +38,26 @@ class BladeRouteGeneratorTest extends TestCase
     }
 
     /** @test */
+    public function can_generate_mergeable_json_payload_on_repeated_compiles()
+    {
+        $router = app('router');
+        $router->get('posts', $this->noop())->name('posts.index');
+        $router->getRoutes()->refreshNameLookups();
+
+        BladeRouteGenerator::$generated = false;
+        (new BladeRouteGenerator)->generate();
+        $script = (new BladeRouteGenerator)->generate();
+
+        $payload = json_decode(Str::after(Str::before($script, ";\n\n"), 'routes = '), true);
+        $this->assertSame([
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+            ],
+        ], json_decode(Str::after(Str::before($script, ";\n\n"), 'routes = '), true));
+    }
+
+    /** @test */
     public function can_generate_routes_for_default_domain()
     {
         $router = app('router');

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -27,6 +27,7 @@ class BladeRouteGeneratorTest extends TestCase
         $router->post('posts', $this->noop())->name('posts.store');
         $router->getRoutes()->refreshNameLookups();
 
+        BladeRouteGenerator::$generated = false;
         $output = (new BladeRouteGenerator)->generate();
         $ziggy = json_decode(Str::after(Str::before($output, ";\n\n"), ' = '), true);
 


### PR DESCRIPTION
This PR fixes the Blade directive so that it correctly merges in just Ziggy's `namedRoutes` on repeated compilations, instead of the whole Ziggy configuration.