### PR TITLE
Revert outputting generated Blade directive contents directly

### DIFF
--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -25,9 +25,7 @@ class ZiggyServiceProvider extends ServiceProvider
     protected function registerDirective(BladeCompiler $bladeCompiler)
     {
         $bladeCompiler->directive('routes', function ($group) {
-            return app()->isLocal()
-                ? "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>"
-                : app(BladeRouteGenerator::class)->generate($group);
+            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
         });
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -106,18 +106,6 @@ class BladeRouteGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function can_compile_routes_directive()
-    {
-        $compiler = app('blade.compiler');
-
-        BladeRouteGenerator::$generated = false;
-        $script = (new BladeRouteGenerator)->generate();
-
-        BladeRouteGenerator::$generated = false;
-        $this->assertSame($script, $compiler->compileString('@routes'));
-    }
-
-    /** @test */
     public function can_output_script_tag()
     {
         $router = app('router');


### PR DESCRIPTION
This PR reverts an earlier change in #315 that dumped the entire generated output of the `BladeRouteGenerator` class into the view.

It turns out this breaks easily in scenarios where views are cached _manually_ with `php artisan view:cache`. The output of the `BladeRouteGenerator` is different the first time it's run, but on a per-request basis—`view:cache` hits every view in the entire app in the same console request, so in an app with multiple layouts for example, only the very first one to be cached will be correct.

This change was originally made to mitigate the performance cost of looking up every route-model binding in the app on each request, but after further tuning that code the performance hit was actually negligible. In the future we could wrap the part of the `Ziggy` class that does this lookup in a `once()`, or cache it, so it at least won't happen multiple times on the same request.