### PR TITLE
Ensure current() method respects 'absolute' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Breaking changes are marked with ⚠️.
 - ⚠️ Make the `filter()` method on the `Ziggy` class return an instance of that class instead of a collection of routes ([#341](https://github.com/tighten/ziggy/pull/341))
 - ⚠️ Make the `nameKeyedRoutes()`, `resolveBindings()`, `applyFilters()`, and `group()` methods on the `Ziggy` class, and the `generate()` method on the `CommandRouteGenerator` class, private ([#341](https://github.com/tighten/ziggy/pull/341))
 - ⚠️ Export from `index.js` instead of `route.js` ([#344](https://github.com/tighten/ziggy/pull/344))
+- ⚠️ Ensure `.current()` respects the value of the `absolute` option ([#353](https://github.com/tighten/ziggy/pull/353))
 
 **Deprecated**
 

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -11,7 +11,7 @@ export default class Route {
         this.name = name;
         this.definition = definition;
         this.bindings = definition.bindings ?? {};
-        this.config = { absolute: true, ...config };
+        this.config = config;
     }
 
     /**

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -15,13 +15,14 @@ export default class Router extends String {
         super();
 
         this._config = config ?? Ziggy ?? globalThis?.Ziggy;
+        this._config = { ...this._config, absolute };
 
         if (name) {
             if (!this._config.routes[name]) {
                 throw new Error(`Ziggy error: route '${name}' is not in the route list.`);
             }
 
-            this._route = new Route(name, this._config.routes[name], { ...this._config, absolute });
+            this._route = new Route(name, this._config.routes[name], this._config);
             this._params = this._parse(params);
         }
     }
@@ -67,7 +68,9 @@ export default class Router extends String {
      * @return {(Boolean|String)}
      */
     current(name, params) {
-        const url = window.location.host + window.location.pathname;
+        const url = this._config.absolute
+            ? window.location.host + window.location.pathname
+            : window.location.pathname.replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '').replace(/^\/+/, '/');
 
         // Find the first route that matches the current URL
         const [current, route] = Object.entries(this._config.routes).find(

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -501,6 +501,34 @@ describe('current()', () => {
         same(route().current(), 'events.venues.index');
     });
 
+    test('can ignore domain when getting current route name and absolute is false', () => {
+        global.window.location.href = 'https://tighten.ziggy.dev/events/1/venues?foo=2';
+        global.window.location.host = 'tighten.ziggy.dev';
+        global.window.location.pathname = '/events/1/venues?foo=2';
+
+        same(route(undefined, undefined, false).current(), 'events.venues.index');
+
+        global.window.location.href = 'https://example.com/events/1/venues?foo=2';
+        global.window.location.host = 'example.com';
+        global.window.location.pathname = '/events/1/venues?foo=2';
+
+        same(route(undefined, undefined, false).current(), 'events.venues.index');
+    });
+
+    test('can ignore domain when getting current route name, absolute is false, and app is in a subfolder', () => {
+        global.Ziggy.url = 'https://tighten.ziggy.dev/subfolder';
+        global.window.location.href = 'https://tighten.ziggy.dev/subfolder/events/1/venues?foo=2';
+        global.window.location.pathname = '/subfolder/events/1/venues?foo=2';
+
+        same(route(undefined, undefined, false).current(), 'events.venues.index');
+
+        global.Ziggy.url = 'https://example.com/nested/subfolder';
+        global.window.location.href = 'https://example.com/nested/subfolder/events/1/venues?foo=2';
+        global.window.location.pathname = '/nested/subfolder/events/1/venues?foo=2';
+
+        same(route(undefined, undefined, false).current(), 'events.venues.index');
+    });
+
     test('can get the current route name with a custom Ziggy object', () => {
         global.Ziggy = undefined;
         global.window.location.pathname = '/events/';


### PR DESCRIPTION
This PR addresses #329 and #348 by ensuring that the `.current()` method will respect Ziggy's `absolute` option. What this means is that now, if you set `absolute` to `false`, `.current()` will only consider the pathname when matching the current window URL.

This is a pretty inelegant solution to that problem but it's technically breaking so I want to make it now. I do want to eventually add a flag to `.current()` itself to accomplish this, or find a better way, but we can add that later in a minor release.

**Before:**

```js
// APP_URL is https://tighten.co

// On URL https://ozzie.tighten.co/projects
route(undefined, undefined, false).current(); // undefined
route(undefined, undefined, false).current('projects.index'); // false

// On URL https://loosen.com/projects
route(undefined, undefined, false).current(); // undefined
route(undefined, undefined, false).current('projects.index'); // false
```

**After:**

```js
// APP_URL is https://tighten.co

// On URL https://ozzie.tighten.co/projects
// Subdomain is ignored because absolute = false
route(undefined, undefined, false).current(); // 'projects.index'
route(undefined, undefined, false).current('projects.index'); // true

// On URL https://loosen.com/projects
// The whole domain is actually ignored, it could be anything, or even missing entirely
route(undefined, undefined, false).current(); // 'projects.index'
route(undefined, undefined, false).current('projects.index'); // true
```