### PR TITLE
Fix route().current() not working on a route at the domain root

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -29,7 +29,7 @@ export default class Route {
             ? `${this.config.url.match(/^\w+:\/\//)[0]}${this.definition.domain}${this.config.port ? `:${this.config.port}` : ''}`
             : this.config.url;
 
-        return `${origin}/${this.definition.uri}`;
+        return `${origin}/${this.definition.uri}`.replace(/\/+$/, '');
     }
 
     /**
@@ -61,8 +61,7 @@ export default class Route {
         const pattern = this.template
             .replace(/\/{[^}?]*\?}/g, '(\/[^/?]+)?')
             .replace(/{[^}]+}/g, '[^/?]+')
-            .replace(/^\w+:\/\//, '')
-            .replace(/\/+$/, '');
+            .replace(/^\w+:\/\//, '');
 
         return new RegExp(`^${pattern}$`).test(url.replace(/\/+$/, '').split('?').shift());
     }

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -61,7 +61,8 @@ export default class Route {
         const pattern = this.template
             .replace(/\/{[^}?]*\?}/g, '(\/[^/?]+)?')
             .replace(/{[^}]+}/g, '[^/?]+')
-            .replace(/^\w+:\/\//, '');
+            .replace(/^\w+:\/\//, '')
+            .replace(/\/+$/, '');
 
         return new RegExp(`^${pattern}$`).test(url.replace(/\/+$/, '').split('?').shift());
     }

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -73,7 +73,7 @@ export default class Route {
      * @return {String}
      */
     compile(params) {
-        if (!this.parameterSegments.length) return this.template.replace(/\/+$/, '');
+        if (!this.parameterSegments.length) return this.template;
 
         return this.template.replace(/{([^}?]+)\??}/g, (_, segment) => {
             // If the parameter is missing but is not optional, throw an error

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -499,6 +499,15 @@ describe('current()', () => {
         same(route().current(), 'events.venues.index');
     });
 
+    test('can get the current route name at the domain root', () => {
+        global.window.location.href = 'https://ziggy.dev';
+        global.window.location.host = 'ziggy.dev';
+        global.window.location.pathname = '/';
+
+        same(route().current(), 'home');
+        same(route().current('home'), true);
+    });
+
     test('can ignore query string when getting current route name', () => {
         global.window.location.pathname = '/events/1/venues?foo=2';
 


### PR DESCRIPTION
Fixes #355, in which `route().current()` and `route().current('home')` didn't work if the route / current URL was just the base domain of the site, e.g. `https://ziggy.test`.

Previously, the URL regex pattern generated and matched for routes like this would have been `ziggy.test//`, which fails, now it's just `ziggy.test`.