### PR TITLE
Fix error calling 'current()' on an unknown route

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -76,7 +76,7 @@ export default class Router extends String {
         // Find the first route that matches the current URL
         const [current, route] = Object.entries(this._config.routes).find(
             ([_, route]) => new Route(name, route, this._config).matchesUrl(url)
-        );
+        ) || [undefined, undefined];
 
         // If a name wasn't passed, return the name of the current route
         if (!name) return current;

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -66,7 +66,7 @@ export default class Router extends String {
      *
      * @param {String} name - Route name to check.
      * @param {(String|Number|Array|Object)} params - Route parameters.
-     * @return {(Boolean|String)}
+     * @return {(Boolean|String|undefined)}
      */
     current(name, params) {
         const url = this._config.absolute

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -560,6 +560,18 @@ describe('current()', () => {
         same(route(undefined, undefined, undefined, config).current(), 'events.index');
     });
 
+    test('can return undefined when getting the current route name on an unknown route', () => {
+        global.window.location.pathname = '/unknown/';
+
+        same(route().current(), undefined);
+    });
+
+    test('can return false when checking the current route name on an unknown route', () => {
+        global.window.location.pathname = '/unknown/';
+
+        same(route().current('posts.delete'), false);
+    });
+
     test('can check the current route name against a pattern', () => {
         global.window.location.pathname = '/events/1/venues/2';
 


### PR DESCRIPTION
After this PR, instead of causing an error, calling `route().current()` on an unknown route (e.g. a route without a name) now returns `undefined`, and passing an invalid route name, for example `route().current('this-route-name-doesnt-exist')`, returns `false`.

Fixes #360. 