### PR TITLE
Exclude cached routes with randomly generated names

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -87,6 +87,9 @@ class Ziggy implements JsonSerializable
     private function nameKeyedRoutes()
     {
         [$fallbacks, $routes] = collect(app('router')->getRoutes()->getRoutesByName())
+            ->reject(function ($route) {
+                return Str::startsWith($route->getName(), 'generated::');
+            })
             ->partition(function ($route) {
                 return $route->isFallback;
             });

--- a/tests/Unit/RouteCachingTest.php
+++ b/tests/Unit/RouteCachingTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Tightenco\Ziggy\Ziggy;
+
+class RouteCachingTest extends TestCase
+{
+    /** @test */
+    public function can_exclude_routes_with_randomly_generated_names()
+    {
+        app('router')->get('users', $this->noop())->name('users');
+        app('router')->get('cached', $this->noop())->name('generated::ZRopaJJwzA27wRLa');
+
+        $expected = [
+            'users' => [
+                'uri' => 'users',
+                'methods' => ['GET', 'HEAD'],
+            ],
+        ];
+
+        $this->assertSame($expected, (new Ziggy)->toArray()['routes']);
+    }
+}

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -336,7 +336,6 @@ class ZiggyTest extends TestCase
     /** @test */
     public function can_order_fallback_routes_last()
     {
-        $ziggy = new Ziggy;
         app('router')->fallback($this->noop())->name('fallback');
         app('router')->get('/users', $this->noop())->name('users.index');
 


### PR DESCRIPTION
When you run `php artisan route:cache`, Laravel assigns unnamed routes a unique, randomly generated name that looks something like `generated::ZRopaJJwzA27wRLa`.

Ziggy should ignore these routes because they don't actually have explicit names assigned by the developer, so including them in the output will increase its size considerably and could expose information that should not be visible client-side.

To that end, this PR just filters out any route whose name starts with `generated::`.

---

I tried to actually cache the routes in a test, but Testbench doesn't support this out of the box and I kept getting very weird Opis/Closure errors. Here's what I was trying, more or less:

```php
    // tests/TestCase.php

    protected function cacheRoutes()
    {
        $routes = app('router')->getRoutes();
        $routes->refreshNameLookups();
        $routes->refreshActionLookups();

        foreach ($routes as $route) {
            $route->prepareForSerialization();
        }

        $this->laravelVersion(7)
            ? app('router')->setCompiledRoutes($routes->compile())
            : app('router')->setRoutes($routes);
    }
```