### PR TITLE
Ensure Ziggy.defaults is always an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     },
     "scripts": {
         "build": "microbundle --name route --format modern,es,umd --external none",
+        "watch": "npm run build watch",
         "build:npm": "microbundle --name route --format modern,es,umd",
         "test": "jest",
         "prepublishOnly": "npm run build:npm"

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -128,7 +128,9 @@ class Ziggy implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return $this->toArray();
+        return array_merge($routes = $this->toArray(), [
+            'defaults' => (object) $routes['defaults'],
+        ]);
     }
 
     /**

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -170,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":[],"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -425,7 +425,6 @@ class ZiggyTest extends TestCase
         $this->addPostCommentsRouteWithBindings($expected['routes']);
 
         $this->assertSame($expected, $ziggy->toArray());
-        $this->assertSame($expected, $ziggy->jsonSerialize());
     }
 
     /** @test */
@@ -449,7 +448,7 @@ class ZiggyTest extends TestCase
 
         $this->addPostCommentsRouteWithBindings($expected['routes']);
 
-        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":[],"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
+const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (let name in window.Ziggy.routes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":[],"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (let name in window.Ziggy.routes) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -111,13 +111,6 @@ const defaultZiggy = {
             uri: 'hosting-contacts',
             methods: ['GET', 'HEAD'],
         },
-        'hq.shifts.update': {
-            uri: 'hq/shifts/{shift}',
-            methods: ['PUT', 'PATCH'],
-            bindings: {
-                shift: 'id',
-            },
-        },
     },
 };
 
@@ -673,12 +666,5 @@ describe('current()', () => {
         global.window.location.pathname = '/events/1/venues/';
 
         same(route().current(), 'events.venues.index');
-    });
-});
-
-describe('bugs', () => {
-    test.only('can generate a URL for a route with a parameter called "shift" when there are no default parameters', () => {
-        global.Ziggy.defaults = [];
-        same(route('hq.shifts.update', 1), 'https://ziggy.dev/hq/shifts/1');
     });
 });

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -111,6 +111,13 @@ const defaultZiggy = {
             uri: 'hosting-contacts',
             methods: ['GET', 'HEAD'],
         },
+        'hq.shifts.update': {
+            uri: 'hq/shifts/{shift}',
+            methods: ['PUT', 'PATCH'],
+            bindings: {
+                shift: 'id',
+            },
+        },
     },
 };
 
@@ -666,5 +673,12 @@ describe('current()', () => {
         global.window.location.pathname = '/events/1/venues/';
 
         same(route().current(), 'events.venues.index');
+    });
+});
+
+describe('bugs', () => {
+    test.only('can generate a URL for a route with a parameter called "shift" when there are no default parameters', () => {
+        global.Ziggy.defaults = [];
+        same(route('hq.shifts.update', 1), 'https://ziggy.dev/hq/shifts/1');
     });
 });


### PR DESCRIPTION
This PR fixes #366 by ensuring that the JavaScript `Ziggy.defaults` property is always an object, even when it's empty.

The bug in #366 happens because previously, when `defaults` was an empty PHP array, it was encoded as an empty JavaScript array too. JavaScript arrays of course have several built-in methods, like `shift()` and `reduce()`, and so if you had a route parameter name that matched one of those methods, and you tried to access it on an array, it would return that method:

```js
const defaults = [];
const name1 = 'users';
const name2 = 'shift';

!!defaults[name1]; // false, because it evaluates to defaults['users'] which doesn't exist
!!defaults[name2]; // true, because it evaluates to defaults['shift'] which DOES exist and is a function
```

If there _are_ default parameters, `defaults` will be an object, which avoids this issue, but if there aren't, it would have been an array, so any route parameter names matching built-in JavaScript array methods would cause errors like this.