### PR TITLE
Fix issues with incorrect `current` result for pure param routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Breaking changes are marked with ⚠️.
 ## UNRELEASED
 
 **Fixed**
-- Routes made of pure params (`{page}`) no longer get matches as when on `/`
+
+- Fix bug where `route().current()` could incorrectly return `true` on URLs with no parameters ([#377](https://github.com/tighten/ziggy/pull/377))
 
 ## [v1.0.3] - 2020-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Breaking changes are marked with ⚠️.
 
+## UNRELEASED
+
+**Fixed**
+- Routes made of pure params (`{page}`) no longer get matches as when on `/`
+
 ## [v1.0.3] - 2020-11-20
 
 **Fixed**

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -9,8 +9,8 @@ export default class Route {
      */
     constructor(name, definition, config) {
         this.name = name;
-        this.definition = definition ?? {};
-        this.bindings = definition ? definition.bindings ?? {} : {};
+        this.definition = definition;
+        this.bindings = definition.bindings ?? {};
         this.config = config;
     }
 

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -9,8 +9,8 @@ export default class Route {
      */
     constructor(name, definition, config) {
         this.name = name;
-        this.definition = definition;
-        this.bindings = definition.bindings ?? {};
+        this.definition = definition ?? {};
+        this.bindings = definition ? definition.bindings ?? {} : {};
         this.config = config;
     }
 

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -245,8 +245,8 @@ export default class Router extends String {
         }
 
         return {
-            ...dehydrate(window.location.host, route ? route.domain : undefined, '.'), // Domain parameters
-            ...dehydrate(pathname, route ? route.uri : undefined, '/'), // Path parameters
+            ...dehydrate(window.location.host, route.domain, '.'), // Domain parameters
+            ...dehydrate(pathname, route.uri, '/'), // Path parameters
             ...parse(window.location.search?.replace(/^\?/, '')), // Query parameters
         };
     }

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -88,13 +88,12 @@ export default class Router extends String {
         if (!params) return match;
 
         params = this._parse(params, new Route(current, route, this._config));
+        const routeParams = Object.entries(this._dehydrate(route));
+
+        // If the current window URL has no parameters, it won't match any that were passed
+        if (!routeParams.length) return false;
 
         // Check that all passed parameters match their values in the current window URL
-        const routeParams = Object.entries(this._dehydrate(route));
-        if(!routeParams.length){
-            return false;
-        }
-
         return routeParams
             .filter(([key]) => params.hasOwnProperty(key))
             // Use weak equality because all values in the current window URL will be strings

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -90,7 +90,12 @@ export default class Router extends String {
         params = this._parse(params, new Route(current, route, this._config));
 
         // Check that all passed parameters match their values in the current window URL
-        return Object.entries(this._dehydrate(route))
+        const routeParams = Object.entries(this._dehydrate(route));
+        if(!routeParams.length){
+            return false;
+        }
+
+        return routeParams
             .filter(([key]) => params.hasOwnProperty(key))
             // Use weak equality because all values in the current window URL will be strings
             .every(([key, value]) => params[key] == value);
@@ -240,8 +245,8 @@ export default class Router extends String {
         }
 
         return {
-            ...dehydrate(window.location.host, route.domain, '.'), // Domain parameters
-            ...dehydrate(pathname, route.uri, '/'), // Path parameters
+            ...dehydrate(window.location.host, route ? route.domain : undefined, '.'), // Domain parameters
+            ...dehydrate(pathname, route ? route.uri : undefined, '/'), // Path parameters
             ...parse(window.location.search?.replace(/^\?/, '')), // Query parameters
         };
     }

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -111,6 +111,10 @@ const defaultZiggy = {
             uri: 'hosting-contacts',
             methods: ['GET', 'HEAD'],
         },
+        'pages': {
+            uri: '{page}',
+            methods: ['GET', 'HEAD'],
+        },
     },
 };
 
@@ -561,9 +565,21 @@ describe('current()', () => {
     });
 
     test('can return undefined when getting the current route name on an unknown route', () => {
-        global.window.location.pathname = '/unknown/';
+        global.window.location.pathname = '/unknown/path';
 
         same(route().current(), undefined);
+    });
+
+    test('can handle pure param routes', () => {
+        global.window.location.pathname = '/some-page';
+
+        assert(route().current('pages', {page: 'some-page'}));
+    });
+
+    test('can handle having no route params', () => {
+        global.window.location.pathname = '/';
+
+        assert(!route().current('pages', {page: 'test-page'}));
     });
 
     test('can return false when checking the current route name on an unknown route', () => {


### PR DESCRIPTION
`route().current('page', {page: 'some-path'})` returns true when on `/`, this fixes that.

I discovered this in my project, where I have the routes

```
Route::get('/', [PageController::class, 'home'])->name('home');
Route::get('/{page}', [PageController::class, 'show'])->name('page');
```

And in my nav `:active=route().current('page', 'about')` was returning true when I was on the home page

Swapping `current` in `dist/index.js` for this verified the fix works in my project too
```
current(t, e) {
            const r = this.t.absolute ? window.location.host + window.location.pathname : window.location.pathname.replace(this.t.url.replace(/^\w*:\/\/[^/]+/, ""), "").replace(/^\/+/, "/"), [n, i] = Object.entries(this.t.routes).find(([e, n]) => new N(t, n, this.t).matchesUrl(r)) || [void 0, void 0];
            if (!t) return n;
            const o = new RegExp("^" + t.replace(".", "\\.").replace("*", ".*") + "$").test(n);
            if(e){
                e = this.s(e, new N(n, i, this.t))
                var z = Object.entries(this.l(i));
                if(!z.length) return false;
                return z.filter(([t]) => e.hasOwnProperty(t)).every(([t, r]) => e[t] == r)
            }
            return o
        }
```