### PR TITLE
Fix bugs calling current() with params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes are marked with ⚠️.
 **Fixed**
 
 - Fix bug where `route().current()` could incorrectly return `true` on URLs with no parameters ([#377](https://github.com/tighten/ziggy/pull/377))
+- Fix several other bugs in `route().current()` with params ([#379](https://github.com/tighten/ziggy/pull/379))
 
 ## [v1.0.3] - 2020-11-20
 

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -89,15 +89,11 @@ export default class Router extends String {
 
         const routeObject = new Route(current, route, this._config);
 
-        // If the matching route has no defined parameters, and the passed
-        // parameters are 'positional' (*not* an object), return false
-        if (
-            !routeObject.parameterSegments.length
-            && (['string', 'number'].includes(typeof params) || Array.isArray(params))
-        ) return false;
-
         params = this._parse(params, routeObject);
         const routeParams = this._dehydrate(route);
+
+        // If the current window URL has no route parameters, and the passed parameters are empty, return true
+        if (Object.values(params).every(p => !p) && !Object.values(routeParams).length) return true;
 
         // Check that all passed parameters match their values in the current window URL
         // Use weak equality because all values in the current window URL will be strings
@@ -151,7 +147,7 @@ export default class Router extends String {
         if (Array.isArray(params)) {
             // If the parameters are an array they have to be in order, so we can transform them into
             // an object by keying them with the template segment names in the order they appear
-            params = params.reduce((result, current, i) => ({ ...result, [segments[i].name]: current }), {});
+            params = params.reduce((result, current, i) => ({ ...result, [segments[i]?.name]: current }), {});
         } else if (
             segments.length === 1
             && !params[segments[0].name]

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -85,7 +85,7 @@ export default class Router extends String {
         // basic wildcards, e.g. passing `events.*` matches `events.show`
         const match = new RegExp(`^${name.replace('.', '\\.').replace('*', '.*')}$`).test(current);
 
-        if (!params || !match) return match;
+        if ([null, undefined].includes(params) || !match) return match;
 
         const routeObject = new Route(current, route, this._config);
 
@@ -93,7 +93,7 @@ export default class Router extends String {
         // parameters are 'positional' (*not* an object), return false
         if (
             !routeObject.parameterSegments.filter(({ name }) => !this._config.defaults[name]).length
-            && (['string', 'number'].includes(typeof params) || (Array.isArray(params) && !!params.length))
+            && (['string', 'number'].includes(typeof params) || Array.isArray(params))
         ) return false;
 
         params = this._parse(params, routeObject);

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -88,16 +88,11 @@ export default class Router extends String {
         if (!params || !match) return match;
 
         params = this._parse(params, new Route(current, route, this._config));
-        const routeParams = Object.entries(this._dehydrate(route));
-
-        // If the current window URL has no parameters, it won't match any that were passed
-        if (!routeParams.length) return false;
+        const routeParams = this._dehydrate(route);
 
         // Check that all passed parameters match their values in the current window URL
-        return routeParams
-            .filter(([key]) => params.hasOwnProperty(key))
-            // Use weak equality because all values in the current window URL will be strings
-            .every(([key, value]) => params[key] == value);
+        // Use weak equality because all values in the current window URL will be strings
+        return Object.entries(params).every(([key, value]) => routeParams[key] == value);
     }
 
     /**

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -197,7 +197,7 @@ export default class Router extends String {
      */
     _substituteBindings(params, bindings = {}) {
         return Object.entries(params).reduce((result, [key, value]) => {
-            // If the value isn't an object, or if it's an object of explicity query
+            // If the value isn't an object, or if it's an object of explicit query
             // parameters, there's nothing to substitute so we return it as-is
             if (!value || typeof value !== 'object' || Array.isArray(value) || key === '_query') {
                 return { ...result, [key]: value };

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -85,7 +85,7 @@ export default class Router extends String {
         // basic wildcards, e.g. passing `events.*` matches `events.show`
         const match = new RegExp(`^${name.replace('.', '\\.').replace('*', '.*')}$`).test(current);
 
-        if (!params) return match;
+        if (!params || !match) return match;
 
         params = this._parse(params, new Route(current, route, this._config));
         const routeParams = Object.entries(this._dehydrate(route));

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -87,7 +87,16 @@ export default class Router extends String {
 
         if (!params || !match) return match;
 
-        params = this._parse(params, new Route(current, route, this._config));
+        const routeObject = new Route(current, route, this._config);
+
+        // If the matching route has no defined parameters, and the passed
+        // parameters are 'positional' (*not* an object), return false
+        if (
+            !routeObject.parameterSegments.filter(({ name }) => !this._config.defaults[name]).length
+            && (['string', 'number'].includes(typeof params) || (Array.isArray(params) && !!params.length))
+        ) return false;
+
+        params = this._parse(params, routeObject);
         const routeParams = this._dehydrate(route);
 
         // Check that all passed parameters match their values in the current window URL

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -92,7 +92,7 @@ export default class Router extends String {
         // If the matching route has no defined parameters, and the passed
         // parameters are 'positional' (*not* an object), return false
         if (
-            !routeObject.parameterSegments.filter(({ name }) => !this._config.defaults[name]).length
+            !routeObject.parameterSegments.length
             && (['string', 'number'].includes(typeof params) || Array.isArray(params))
         ) return false;
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -692,22 +692,22 @@ describe('current()', () => {
     test('can check the current route with parameters', () => {
         global.window.location.pathname = '/events/1/venues/2';
 
-        assert(route().current('events.venues.show', { event: 1, venue: 2 }));
-        assert(route().current('events.venues.show', [1, 2]));
-        assert(route().current('events.venues.show', [1, { id: 2, name: 'Grand Canyon' }]));
-        assert(route().current('events.venues.show', { event: 1 }));
-        assert(route().current('events.venues.show', { venue: 2 }));
-        assert(route().current('events.venues.show', [1]));
-        assert(route().current('events.venues.show', {}));
-        assert(route().current('events.venues.show', null));
+        same(route().current('events.venues.show', { event: 1, venue: 2 }), true);
+        same(route().current('events.venues.show', [1, 2]), true);
+        same(route().current('events.venues.show', [1, { id: 2, name: 'Grand Canyon' }]), true);
+        same(route().current('events.venues.show', { event: 1 }), true);
+        same(route().current('events.venues.show', { venue: 2 }), true);
+        same(route().current('events.venues.show', [1]), true);
+        same(route().current('events.venues.show', {}), true);
+        same(route().current('events.venues.show', null), true);
 
-        assert(!route().current('events.venues.show', { event: 4, venue: 2 }));
-        assert(!route().current('events.venues.show', { event: null }));
-        assert(!route().current('events.venues.show', [1, 6]));
-        assert(!route().current('events.venues.show', [{ id: 1 }, { id: 4, name: 'Great Pyramids' }]));
-        assert(!route().current('events.venues.show', { event: 4 }));
-        assert(!route().current('events.venues.show', { venue: 4 }));
-        assert(!route().current('events.venues.show', [5]));
+        same(route().current('events.venues.show', { event: 4, venue: 2 }), false);
+        same(route().current('events.venues.show', { event: null }), false);
+        same(route().current('events.venues.show', [1, 6]), false);
+        same(route().current('events.venues.show', [{ id: 1 }, { id: 4, name: 'Great Pyramids' }]), false);
+        same(route().current('events.venues.show', { event: 4 }), false);
+        same(route().current('events.venues.show', { venue: 4 }), false);
+        same(route().current('events.venues.show', [5]), false);
     });
 
     test('can check the current route with query parameters', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -564,28 +564,83 @@ describe('current()', () => {
         same(route(undefined, undefined, undefined, config).current(), 'events.index');
     });
 
-    test('can return undefined when getting the current route name on an unknown route', () => {
+    test('can return undefined when getting the current route name on an unknown URL', () => {
         global.window.location.pathname = '/unknown/path';
 
         same(route().current(), undefined);
     });
 
-    test('can handle pure param routes', () => {
+    test('can check the current route name on a route/URL made up entirely of a single parameter', () => {
         global.window.location.pathname = '/some-page';
 
-        assert(route().current('pages', {page: 'some-page'}));
+        same(route().current(), 'pages');
+        same(route().current('pages', { page: 'some-page' }), true);
     });
 
-    test('can handle having no route params', () => {
+    test('can check the current route name with parameters on a URL with no parameters', () => {
+        global.window.location.href = 'https://ziggy.dev';
+        global.window.location.host = 'ziggy.dev';
         global.window.location.pathname = '/';
 
-        assert(!route().current('pages', {page: 'test-page'}));
+        same(route().current('home', { page: 'test' }), false);
+        same(route().current('pages', { page: 'test' }), false);
+
+        global.window.location.pathname = '/posts/';
+
+        same(route().current('posts.index', { post: 1 }), false);
+        same(route().current('posts.show', { post: 1 }), false);
+    });
+
+    test.skip('can check the current route name with positional parameters on a URL with no parameters', () => {
+        global.window.location.pathname = '/posts/';
+
+        same(route().current('posts.index', 'test'), false);
+        same(route().current('posts.index', [1]), false);
     });
 
     test('can return false when checking the current route name on an unknown route', () => {
         global.window.location.pathname = '/unknown/';
 
         same(route().current('posts.delete'), false);
+    });
+
+    test('can return false when checking the current route name and params on an unknown URL', () => {
+        global.window.location.pathname = '/unknown/path';
+
+        same(route().current('posts.show', { post: 2 }), false);
+        same(route().current('posts.show', 2), false);
+        same(route().current('posts.show', [2]), false);
+        same(route().current('posts.show', 'post'), false);
+    });
+
+    test('can return false when checking a non-existent route name on a known URL', () => {
+        global.window.location.pathname = '/events/1/venues/2';
+
+        same(route().current('random-route'), false);
+    });
+
+    test('can return false when checking a non-existent route name on an unknown URL', () => {
+        global.window.location.pathname = '/unknown/test';
+
+        same(route().current('random-route'), false);
+    });
+
+    test('can return false when checking a non-existent route name and params on a known URL', () => {
+        global.window.location.pathname = '/events/1/venues/2';
+
+        same(route().current('random-route', { post: 2 }), false);
+        same(route().current('random-route', 2), false);
+        same(route().current('random-route', [2]), false);
+        same(route().current('random-route', 'post'), false);
+    });
+
+    test('can return false when checking a non-existent route name and params on an unknown URL', () => {
+        global.window.location.pathname = '/unknown/params';
+
+        same(route().current('random-route', { post: 2 }), false);
+        same(route().current('random-route', 2), false);
+        same(route().current('random-route', [2]), false);
+        same(route().current('random-route', 'post'), false);
     });
 
     test('can check the current route name against a pattern', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -597,12 +597,12 @@ describe('current()', () => {
 
         same(route().current('posts.index', undefined), true);
         same(route().current('posts.index', null), true);
-        same(route().current('posts.index', ''), true);
-        same(route().current('posts.index', []), true);
         same(route().current('posts.index', {}), true);
         same(route().current('posts.index', { '0': 'test' }), true);
 
+        same(route().current('posts.index', ''), false);
         same(route().current('posts.index', 'test'), false);
+        same(route().current('posts.index', []), false);
         same(route().current('posts.index', [1]), false);
     });
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -111,6 +111,10 @@ const defaultZiggy = {
             uri: 'hosting-contacts',
             methods: ['GET', 'HEAD'],
         },
+        'pages.optional': {
+            uri: 'optionalpage/{page?}',
+            methods: ['GET', 'HEAD'],
+        },
         'pages': {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
@@ -577,6 +581,30 @@ describe('current()', () => {
         same(route().current('pages', { page: 'some-page' }), true);
     });
 
+    test('can check the current route name on a route/URL made up entirely of a single optional parameter', () => {
+        global.window.location.pathname = '/optionalpage/foo';
+
+        same(route().current(), 'pages.optional');
+        same(route().current('pages.optional', ''), false);
+        same(route().current('pages.optional', ['']), false);
+        // same(route().current('pages.optional', []), false); // Not supported
+        same(route().current('pages.optional', { page: '' }), false);
+        same(route().current('pages.optional', { page: undefined }), false);
+        same(route().current('pages.optional', { page: 'foo' }), true);
+    });
+
+    test('can check the current route name on a route/URL made up entirely of a single optional parameter and with that parameter missing', () => {
+        global.window.location.pathname = '/optionalpage';
+
+        same(route().current(), 'pages.optional');
+        same(route().current('pages.optional', ''), true);
+        // same(route().current('pages.optional', []), true); // Not supported
+        same(route().current('pages.optional', ['']), true);
+        same(route().current('pages.optional', { page: '' }), true);
+        same(route().current('pages.optional', { page: undefined }), true);
+        same(route().current('pages.optional', { page: 'foo' }), false);
+    });
+
     test('can check the current route name with parameters on a URL with no parameters', () => {
         global.window.location.href = 'https://ziggy.dev';
         global.window.location.host = 'ziggy.dev';
@@ -602,7 +630,8 @@ describe('current()', () => {
 
         same(route().current('posts.index', ''), false);
         same(route().current('posts.index', 'test'), false);
-        same(route().current('posts.index', []), false);
+        // same(route().current('posts.index', []), false); // Not supported
+        same(route().current('posts.index', ['']), false);
         same(route().current('posts.index', [1]), false);
     });
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -591,8 +591,16 @@ describe('current()', () => {
         same(route().current('posts.show', { post: 1 }), false);
     });
 
-    test.skip('can check the current route name with positional parameters on a URL with no parameters', () => {
-        global.window.location.pathname = '/posts/';
+    test('can check the current route name with positional parameters on a URL with no parameters', () => {
+        global.window.location.pathname = '/posts';
+        global.window.location.search = '?0=test';
+
+        same(route().current('posts.index', undefined), true);
+        same(route().current('posts.index', null), true);
+        same(route().current('posts.index', ''), true);
+        same(route().current('posts.index', []), true);
+        same(route().current('posts.index', {}), true);
+        same(route().current('posts.index', { '0': 'test' }), true);
 
         same(route().current('posts.index', 'test'), false);
         same(route().current('posts.index', [1]), false);

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -710,6 +710,12 @@ describe('current()', () => {
         same(route().current('events.venues.show', [5]), false);
     });
 
+    test('can check the current route with parameters with incorrect parameter names', () => {
+        global.window.location.pathname = '/events/1/venues/2';
+
+        same(route().current('events.venues.show', { eventz: 2 }), false);
+    });
+
     test('can check the current route with query parameters', () => {
         global.window.location.pathname = '/events/1/venues/2';
         global.window.location.search = '?user=Jacob&id=9';


### PR DESCRIPTION
This PR fixes three issues with the `current()` method:

1. Passing a second argument to `current()` causes the method to ignore a mismatched or non-existent route name, so it either triggers an error or returns `true`.
1. Named parameters passed in the second argument to `current()`, with names that don't match any route or query parameters, are silently ignored, and the method returns `true`.
1.  Passing a string or array as the second argument to `current()` for a route with no parameters triggers an error or incorrectly returns `true`.

To expand on #​3: this PR adds support for explicitly checking for the _absence_ of a parameter by passing `''` as the second argument to `current()`. Note that passing an empty array here is **not** supported.

Closes #378 and #380.