### PR TITLE
Revert #334 "Use APP_URL instead of url() helper"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Breaking changes are marked with ⚠️.
 
 - Fix bug where `route().current()` could incorrectly return `true` on URLs with no parameters ([#377](https://github.com/tighten/ziggy/pull/377))
 - Fix several other bugs in `route().current()` with params ([#379](https://github.com/tighten/ziggy/pull/379))
+- Revert [#334](https://github.com/tighten/ziggy/pull/334), default Ziggy's `url` back to `url('/')` instead of the `APP_URL` environment variable ([#386](https://github.com/tighten/ziggy/pull/386))
+
 
 ## [v1.0.3] - 2020-11-20
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,7 +32,6 @@ Ziggy `1.0` includes significant improvements and changes, most of which won't r
   - [`baseProtocol` and `baseDomain` properties removed](#user-content-base-protocol-domain-removed)
   - [`base` and other prefixes removed](#user-content-prefixes-removed)
   - [`filter()` method made fluent](#user-content-filter-fluent)
-  - [Base URL defaults to `APP_URL`](#user-content-app-url)
   - [Unused PHP methods removed](#user-content-unused-php-removed)
   - [Internal PHP methods made private](#user-content-internal-methods-private)
   - [Undocumented Javascript methods removed](#user-content-undocumented-methods-removed)
@@ -243,17 +242,6 @@ Ziggy `1.0` includes significant improvements and changes, most of which won't r
    The `filter()` method on the `Ziggy` class now returns an instance of `Ziggy` instead of a collection of routes.
 
    See [#341](https://github.com/tighten/ziggy/pull/341)
-   </details>
-
-1. **The base URL is now the `APP_URL` environment variable.** <span id="app-url"></span>
-
-   <details>
-   <summary>Details</summary>
-   <p></p>
-
-   Ziggy's `url` config value, the base URL used to build all routes and URL strings, now uses the value of the `APP_URL` environment variable, and only falls back to `url('/')` if `APP_URL` isn't set.
-
-   See [#334](https://github.com/tighten/ziggy/pull/334)
    </details>
 
 1. **Unused PHP methods were removed.** <span id="unused-php-removed"></span>

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -19,7 +19,7 @@ class Ziggy implements JsonSerializable
     {
         $this->group = $group;
 
-        $this->url = rtrim($url ?? config('app.url', url('/')), '/');
+        $this->url = rtrim($url ?? url('/'), '/');
         $this->port = parse_url($this->url)['port'] ?? null;
 
         $this->routes = $this->nameKeyedRoutes();

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -295,7 +295,9 @@ class ZiggyTest extends TestCase
     /** @test */
     public function can_include_subdomain()
     {
-        app('router')->domain('{team}.ziggy.dev')->post('/', fn () => response()->json(new Ziggy))->name('home');
+        app('router')->domain('{team}.ziggy.dev')->post('/', function () {
+            return response()->json(new Ziggy);
+        })->name('home');
         app('router')->getRoutes()->refreshNameLookups();
 
         $this->post(route('home', ['team' => 'tgtn']))
@@ -307,7 +309,9 @@ class ZiggyTest extends TestCase
     /** @test */
     public function can_include_port()
     {
-        app('router')->post('/', fn () => response()->json(new Ziggy))->name('home');
+        app('router')->post('/', function () {
+            return response()->json(new Ziggy);
+        })->name('home');
         app('router')->getRoutes()->refreshNameLookups();
 
         $this->post('http://ziggy.dev:3000')

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -293,6 +293,31 @@ class ZiggyTest extends TestCase
     }
 
     /** @test */
+    public function can_include_subdomain()
+    {
+        app('router')->domain('{team}.ziggy.dev')->post('/', fn () => response()->json(new Ziggy))->name('home');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->post(route('home', ['team' => 'tgtn']))
+            ->assertJson([
+                'url' => 'http://tgtn.ziggy.dev',
+            ]);
+    }
+
+    /** @test */
+    public function can_include_port()
+    {
+        app('router')->post('/', fn () => response()->json(new Ziggy))->name('home');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->post('http://ziggy.dev:3000')
+            ->assertJson([
+                'url' => 'http://ziggy.dev:3000',
+                'port' => 3000,
+            ]);
+    }
+
+    /** @test */
     public function can_include_only_middleware_set_in_config()
     {
         config(['ziggy' => [


### PR DESCRIPTION
This PR reverts #334 and switches back to using `url('/')` as the base URL, instead of the value of the `APP_URL` environment variable. That change caused subdomains and ports to stop working, which are both quite common use cases.

This PR will cause issues again in environments like those described in #313. @claudiodekker I'll work an alternative solution—sorry to break this again, but it's ended up causing more problems than it solved.

Fixes #383, fixes #376, and fixes #374.