### PR TITLE
Add support for appending 'extra' params to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Breaking changes are marked with ⚠️.
 
 ## [Unreleased]
 
+**Added**
+
+- Add support for appending 'extra' parameters to the query string ([#390](https://github.com/tighten/ziggy/pull/390))
+
 ## [v1.0.4] - 2020-12-06
 
 **Fixed**

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -147,7 +147,7 @@ export default class Router extends String {
         if (Array.isArray(params)) {
             // If the parameters are an array they have to be in order, so we can transform them into
             // an object by keying them with the template segment names in the order they appear
-            params = params.reduce((result, current, i) => ({ ...result, [segments[i]?.name]: current }), {});
+            params = params.reduce((result, current, i) => !!segments[i] ? ({ ...result, [segments[i].name]: current }) : ({ ...result, [current]: '' }), {});
         } else if (
             segments.length === 1
             && !params[segments[0].name]

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -473,6 +473,18 @@ describe('route()', () => {
 
         deepEqual(route().params, { event: '1', venue: '2', id: '5', vip: '0' });
     });
+
+    test("can append 'extra' string/number parameter to query", () => {
+        // 'posts.index' has no parameters
+         same(route('posts.index', 'extra'), 'https://ziggy.dev/posts?extra=');
+         same(route('posts.index', 1), 'https://ziggy.dev/posts?1=');
+    });
+
+    test("can append 'extra' string/number elements in array of parameters to query", () => {
+        // 'posts.show' has exactly one parameter
+         same(route('posts.show', [1, 2]), 'https://ziggy.dev/posts/1?2=');
+         same(route('posts.show', ['my-first-post', 'foo', 'bar']), 'https://ziggy.dev/posts/my-first-post?foo=&bar=');
+    });
 });
 
 describe('has()', () => {


### PR DESCRIPTION
This PR changes Ziggy's handling of 'extra' parameters to append them to the query, similarly to Laravel's `route()` helper, instead of causing an error.

Closes #375.