### PR TITLE
Small change to docs on Webpack Mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,15 @@ You can optionally create a webpack alias to make importing Ziggy's core source 
 // webpack.mix.js
 
 // Mix v6
+const path = require('path')
+
 mix.alias({
     ziggy: path.resolve('vendor/tightenco/ziggy/dist'),
 });
 
 // Mix v5
+const path = require('path')
+
 mix.webpackConfig({
     resolve: {
         alias: {


### PR DESCRIPTION
Laravel's default webpack mix file doesn't contain an import for path, so following the docs for someone less experienced will result in a compile error for the ziggy alias import. This is a slight one line tweak in the docs for beginners.