### PR TITLE
Use Laravel's Reflector class to get model parameter class name

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -4,6 +4,7 @@ namespace Tightenco\Ziggy;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use JsonSerializable;
 use ReflectionMethod;
@@ -155,7 +156,7 @@ class Ziggy implements JsonSerializable
             $bindings = [];
 
             foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-                $model = $parameter->getType()->getName();
+                $model = Reflector::getParameterClassName($parameter);
                 $override = $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
 
                 // Avoid booting this model if it doesn't override the default route key name

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -156,7 +156,9 @@ class Ziggy implements JsonSerializable
             $bindings = [];
 
             foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-                $model = Reflector::getParameterClassName($parameter);
+                $model = class_exists(Reflector::class)
+                    ? Reflector::getParameterClassName($parameter)
+                    : $parameter->getType()->getName();
                 $override = $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
 
                 // Avoid booting this model if it doesn't override the default route key name


### PR DESCRIPTION
Closes #391. See also laravel/framework#33177.