### PR TITLE
Add Vue 2 & 3 Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,34 +342,32 @@ route('home', undefined, undefined, Ziggy);
 
 #### Vue
 
-To use the `route()` helper in Vue components, you can add a mixin to make it available globally:
+To use the `route()` helper in Vue components, you can use the Vue plugin:
 
 ```js
 // app.js
 
-import route from 'ziggy';
-import { Ziggy } from './ziggy';
+// Vue 2
+import Vue from 'vue'
+import {Vue2Plugin } from 'ziggy';
 
-Vue.mixin({
-    methods: {
-        route: (name, params, absolute, config = Ziggy) => route(name, params, absolute, config),
-    },
-});
+Vue.use(Vue2Plugin)
+
+// Vue 3
+import { createApp, h } from 'vue';
+import {Vue3Plugin } from 'ziggy';
+import App from './App'
+
+createApp({
+  render: () => h(App),
+}).use(Vue3Plugin)
 ```
-
-> Note: If you include the `@routes` Blade directive in your views, the `route()` helper will already be available globally, including in your Vue app, so you don't need to import `route` or `Ziggy`. For convenience, you can optionally create a simpler version of the above mixin to make `route()` easily accessibly inside your components:
->
-> ```js
-> Vue.mixin({ methods: { route }});
-> ```
 
 Now you can use the method in your Vue components like so:
 
 ```html
 <a class="nav-link" :href="route('home')">Home</a>
 ```
-
-Thanks to [Scott Christianson](https://github.com/Archer70) for originally sharing [this solution](https://github.com/tighten/ziggy/issues/70#issuecomment-369129032)!
 
 #### React
 

--- a/README.md
+++ b/README.md
@@ -349,13 +349,13 @@ To use the `route()` helper in Vue components, you can use the Vue plugin:
 
 // Vue 2
 import Vue from 'vue'
-import {Vue2Plugin } from 'ziggy';
+import { Vue2Plugin } from 'ziggy';
 
 Vue.use(Vue2Plugin)
 
 // Vue 3
 import { createApp, h } from 'vue';
-import {Vue3Plugin } from 'ziggy';
+import { Vue3Plugin } from 'ziggy';
 import App from './App'
 
 createApp({

--- a/README.md
+++ b/README.md
@@ -342,28 +342,27 @@ route('home', undefined, undefined, Ziggy);
 
 #### Vue
 
-To use the `route()` helper in Vue components, you can use the Vue plugin:
+Ziggy includes a Vue plugin to make it easy to use the `route()` helper throughout your Vue app:
 
 ```js
-// app.js
+import { createApp } from 'vue';
+import { ZiggyVue } from 'ziggy';
+import { Ziggy } from './ziggy';
+import App from './App';
+
+createApp(App).use(ZiggyVue, Ziggy);
 
 // Vue 2
 import Vue from 'vue'
-import { Vue2Plugin } from 'ziggy';
+import { ZiggyVue } from 'ziggy';
+import { Ziggy } from './ziggy';
 
-Vue.use(Vue2Plugin)
-
-// Vue 3
-import { createApp, h } from 'vue';
-import { Vue3Plugin } from 'ziggy';
-import App from './App'
-
-createApp({
-  render: () => h(App),
-}).use(Vue3Plugin)
+Vue.use(ZiggyVue, Ziggy);
 ```
 
-Now you can use the method in your Vue components like so:
+> Note: If you use the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object and pass it into `use()`.
+
+Now you can use `route()` anywhere in your Vue components and templates, like so:
 
 ```html
 <a class="nav-link" :href="route('home')">Home</a>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,3 +5,15 @@ export default function route(name, params, absolute, config) {
 
     return name ? router.toString() : router;
 }
+
+export const Vue2Plugin = {
+    install(Vue) {
+        Vue.mixin({ methods: { route } })
+    },
+}
+
+export const Vue3Plugin = {
+    install: app => {
+        app.mixin({ methods: { route } })
+    }
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,14 +6,10 @@ export default function route(name, params, absolute, config) {
     return name ? router.toString() : router;
 }
 
-export const Vue2Plugin = {
-    install(Vue) {
-        Vue.mixin({ methods: { route } })
-    },
-}
-
-export const Vue3Plugin = {
-    install: app => {
-        app.mixin({ methods: { route } })
-    }
-}
+export const ZiggyVue = {
+    install: (v, options) => v.mixin({
+        methods: {
+            route: (name, params, absolute, config = options) => route(name, params, absolute, config),
+        },
+    }),
+};


### PR DESCRIPTION
This PR adds a little cute integration with Vue 2 and 3.

Usage:
```js
// app.js

// Vue 2
import Vue from 'vue'
import { Vue2Plugin } from 'ziggy';

Vue.use(Vue2Plugin)

// Vue 3
import { createApp, h } from 'vue';
import { Vue3Plugin } from 'ziggy';
import App from './App'

createApp({
  render: () => h(App),
}).use(Vue3Plugin)
```