### PR TITLE
Improve route generation performance on Octane

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -6,7 +6,7 @@ class BladeRouteGenerator
 {
     public static $generated;
 
-    protected static $payload;
+    private static $payload;
 
     public function generate($group = false, $nonce = false)
     {

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -6,22 +6,28 @@ class BladeRouteGenerator
 {
     public static $generated;
 
+    protected static $payload;
+
     public function generate($group = false, $nonce = false)
     {
-        $payload = new Ziggy($group);
+        if (! static::$payload) {
+            static::$payload = new Ziggy($group);
+        }
+
         $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (static::$generated) {
-            return $this->generateMergeJavascript(json_encode($payload->toArray()['routes']), $nonce);
+            return $this->generateMergeJavascript(json_encode(static::$payload->toArray()['routes']), $nonce);
         }
 
+        $ziggy = static::$payload->toJson();
         $routeFunction = $this->getRouteFunction();
 
         static::$generated = true;
 
         return <<<HTML
 <script type="text/javascript"{$nonce}>
-    const Ziggy = {$payload->toJson()};
+    const Ziggy = {$ziggy};
 
     $routeFunction
 </script>

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -5,8 +5,7 @@ namespace Tightenco\Ziggy;
 class BladeRouteGenerator
 {
     public static $generated;
-
-    private static $payload;
+    public static $payload;
 
     public function generate($group = false, $nonce = false)
     {

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -9,6 +9,13 @@ use Tightenco\Ziggy\Ziggy;
 
 class BladeRouteGeneratorTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        BladeRouteGenerator::$payload = null;
+
+        parent::tearDown();
+    }
+
     /** @test */
     public function can_resolve_generator_from_container()
     {
@@ -119,6 +126,7 @@ class BladeRouteGeneratorTest extends TestCase
         $this->assertArrayHasKey('posts.show', $ziggy['routes']);
 
         BladeRouteGenerator::$generated = false;
+        BladeRouteGenerator::$payload = null;
         $output = (new BladeRouteGenerator)->generate(['guest', 'admin']);
         $ziggy = json_decode(Str::after(Str::before($output, ";\n\n"), ' = '), true);
 


### PR DESCRIPTION
This PR builds on #415 and improves performance slightly on Octane. It caches the Ziggy instance in a new static `$payload` property, which will only be generated once per application instance / Octane worker, since this is the bulk of the work Ziggy does and an application's routes likely won't change between requests in production.

The existing static `$generated` property is still used to determine whether Ziggy's JavaScript has been rendered yet during the current request, and this is reset on new Octane requests so that Ziggy's script tags are generated properly.

@taylorotwell I'm assuming that the issue you saw with Ziggy on Octane was just the script tags being rendered incorrectly? If you have a second to look at this and let me know if there was anything more that I'm missing, that would be great.