### PR TITLE
fix: simplify merge

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -40,9 +40,7 @@ HTML;
     (function () {
         const routes = {$json};
 
-        for (let name in routes) {
-            Ziggy.routes[name] = routes[name];
-        }
+        Object.assign(Ziggy.routes, routes);
     })();
 </script>
 HTML;

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -40,9 +40,7 @@ class CommandRouteGenerator extends Command
 const Ziggy = {$payload};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (let name in window.Ziggy.routes) {
-        Ziggy.routes[name] = window.Ziggy.routes[name];
-    }
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
 }
 
 export { Ziggy };

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -182,9 +182,7 @@ HTML,
     (function () {
         const routes = {$json};
 
-        for (let name in routes) {
-            Ziggy.routes[name] = routes[name];
-        }
+        Object.assign(Ziggy.routes, routes);
     })();
 </script>
 HTML,

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,9 +1,7 @@
 const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (let name in window.Ziggy.routes) {
-        Ziggy.routes[name] = window.Ziggy.routes[name];
-    }
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
 }
 
 export { Ziggy };

--- a/tests/fixtures/custom-pathname.js
+++ b/tests/fixtures/custom-pathname.js
@@ -1,9 +1,7 @@
 const Ziggy = {"url":"http:\/\/ziggy.dev\/foo\/bar","port":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (let name in window.Ziggy.routes) {
-        Ziggy.routes[name] = window.Ziggy.routes[name];
-    }
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
 }
 
 export { Ziggy };

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,9 +1,7 @@
 const Ziggy = {"url":"http:\/\/example.org","port":null,"defaults":{"locale":"en"},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (let name in window.Ziggy.routes) {
-        Ziggy.routes[name] = window.Ziggy.routes[name];
-    }
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
 }
 
 export { Ziggy };

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,9 +1,7 @@
 const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
-    for (let name in window.Ziggy.routes) {
-        Ziggy.routes[name] = window.Ziggy.routes[name];
-    }
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
 }
 
 export { Ziggy };


### PR DESCRIPTION
I think this PR should simplify the merge and also solve the Typescript issue that appears when you export it as a ts file:
```
Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ "debugbar.openhandler": { uri: string; methods: string[]; }; "debugbar.clockwork": { uri: string; methods: string[]; }; "debugbar.telescope": { uri: string; methods: string[]; }; "debugbar.assets.css": { uri: string; methods: string[]; }; ... 98 more ...; "team-billing.checkOut": { ...; }; }'.
```