### PR TITLE
Fix for laravel versions without reflection api support (resolves #437)

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -89,7 +89,7 @@ class Ziggy implements JsonSerializable
     {
         $isExcluded = false;
 
-        // return unfiltered routes if user set both config options.
+        // return unfiltered routes if user set both config options
         if (config()->has('ziggy.except') && config()->has('ziggy.only')) {
             return $isExcluded;
         }
@@ -105,26 +105,26 @@ class Ziggy implements JsonSerializable
             }
         }
 
-        // filter out any routes in except, unless included in groups
+        // exclude any routes in except, unless included in groups
         if (config()->has('ziggy.except')) {
             $exclusions = config('ziggy.except');
 
             if (!empty($groupInclusions)) {
-                $exclusions = Arr::where($exclusions, function ($value) use ($groupInclusions) {
-                    return !in_array($value, $groupInclusions);
+                $exclusions = Arr::where($exclusions, function ($exclusion) use ($groupInclusions) {
+                    return !in_array($exclusion, $groupInclusions);
                 });
             }
 
             foreach ($exclusions as $exclusion) {
                 if (Str::is($exclusion, $routeName)) {
                     $isExcluded = true;
-                };
+                }
             }
 
             return $isExcluded;
         }
 
-        // filter out any routes not in only or groups
+        // exclude any routes not in only or groups
         if (config()->has('ziggy.only')) {
             $inclusions = array_merge(config('ziggy.only'), $groupInclusions);
             $isExcluded = true;
@@ -132,7 +132,7 @@ class Ziggy implements JsonSerializable
             foreach ($inclusions as $inclusion) {
                 if (Str::is($inclusion, $routeName)) {
                     $isExcluded = false;
-                };
+                }
             }
 
             return $isExcluded;

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -83,9 +83,9 @@ class Ziggy implements JsonSerializable
     }
 
      /**
-     * Check if route names are filtered
+     * Check if route name is excluded
      */
-    private function checkFilters($routeName)
+    private function isExcluded($routeName)
     {
         $isExcluded = false;
 
@@ -151,7 +151,7 @@ class Ziggy implements JsonSerializable
                 return Str::startsWith($route->getName(), 'generated::');
             })
             ->reject(function ($route) {
-                return $this->checkFilters($route->getName());
+                return $this->isExcluded($route->getName());
             })
             ->partition(function ($route) {
                 return $route->isFallback;

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -109,11 +109,13 @@ class Ziggy implements JsonSerializable
         if (config()->has('ziggy.except')) {
             $exclusions = config('ziggy.except');
 
-            $exclusions = Arr::where($exclusions, function ($value, $key) use ($groupInclusions) {
-                foreach ($groupInclusions as $group) {
-                    return ($value !== $group);
-                }
-            });
+            if (!empty($groupInclusions)) {
+                $exclusions = Arr::where($exclusions, function ($value) use ($groupInclusions) {
+                    foreach ($groupInclusions as $group) {
+                        return ($value !== $group);
+                    }
+                });
+            }
 
             foreach ($exclusions as $exclusion) {
                 if (Str::is($exclusion, $routeName)) {

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -111,9 +111,7 @@ class Ziggy implements JsonSerializable
 
             if (!empty($groupInclusions)) {
                 $exclusions = Arr::where($exclusions, function ($value) use ($groupInclusions) {
-                    foreach ($groupInclusions as $group) {
-                        return ($value !== $group);
-                    }
+                    return !in_array($value, $groupInclusions);
                 });
             }
 


### PR DESCRIPTION
This PR resolves the issue originally raised in #358. I appreciate the root cause is not with Ziggy, but I've created a solution that allows backwards compatibility for those using Laravel <6.18.17 with [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar).

### Context

The root issue was resolved in [Laravel 6.18.17](https://github.com/laravel/framework/releases/tag/v6.18.17):
- Support PHP 8's reflection API ([#33039](https://github.com/laravel/framework/pull/33039))

For those using earlier versions, I've resolved the error by bringing forward the point at which any excluded route names are filtered out. This means that excluding debugbar via the config...
```
// config/ziggy.php

return [
    'except' => ['debugbar.*'],
];
```

...now resolves the error, as previously the error was encountered before the filtering took place.

And now I can successfully generate a ziggy file 😄 

```
File generated!
```

### New Unit Tests

```
 ✔ IsExcluded can identify excluded route via except
 ✔ IsExcluded can identify excluded route via only
 ✔ IsExcluded can identify included route via only
 ✔ IsExcluded can identify included route via groups
 ✔ IsExcluded can identify included route via groups when only is also set
 ✔ IsExcluded can identify route in both excluded and groups as included
 ✔ IsExcluded can ignore excluded route when both except and only are set
 ✔ IsExcluded can ignore route when no config set
```