### PR TITLE
Fix property mangling and implement ES5 compatibility properly

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,4 @@
 module.exports = {
-    presets: [
-        ['@babel/preset-env', { targets: 'defaults, not IE 11' }],
-    ],
     plugins: ['@babel/plugin-proposal-optional-chaining'],
     env: {
         test: {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "watch": "npm run build watch",
         "build:npm": "microbundle --name route --format modern,es,umd --no-sourcemap",
         "build:npm:vue": "microbundle --entry src/js/vue.js --output dist/vue.js --name ZiggyVue --format modern,es,umd --no-sourcemap",
-        "test": "jest",
+        "test": "jest --verbose",
         "prepublishOnly": "npm run build:npm && npm run build:npm:vue"
     },
     "mangle": {
@@ -57,7 +57,7 @@
     "devDependencies": {
         "@babel/preset-env": "^7.11.0",
         "babel-preset-power-assert": "^3.0.0",
-        "jest": "^26.2.2",
+        "jest": "^27.0.6",
         "microbundle": "^0.12.3",
         "power-assert": "^1.6.1"
     }

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -70,8 +70,8 @@ export default class Router extends String {
      */
     current(name, params) {
         const url = this._config.absolute
-            ? this._location.host + this._location.pathname
-            : this._location.pathname.replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '').replace(/^\/+/, '/');
+            ? this._location().host + this._location().pathname
+            : this._location().pathname.replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '').replace(/^\/+/, '/');
 
         // Find the first route that matches the current URL
         const [current, route] = Object.entries(this._config.routes).find(
@@ -106,7 +106,7 @@ export default class Router extends String {
      *
      * @return {Object}
      */
-    get _location() {
+    _location() {
         const { host = '', pathname = '', search = '' } = typeof window !== 'undefined' ? window.location : {};
 
         return {
@@ -239,7 +239,7 @@ export default class Router extends String {
      * @return {Object} Parameters.
      */
     _dehydrate(route) {
-        let pathname = this._location.pathname
+        let pathname = this._location().pathname
             // If this Laravel app is in a subdirectory, trim the subdirectory from the path
             .replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '')
             .replace(/^\/+/, '');
@@ -260,9 +260,9 @@ export default class Router extends String {
         }
 
         return {
-            ...dehydrate(this._location.host, route.domain, '.'), // Domain parameters
+            ...dehydrate(this._location().host, route.domain, '.'), // Domain parameters
             ...dehydrate(pathname, route.uri, '/'), // Path parameters
-            ...parse(this._location.search?.replace(/^\?/, '')), // Query parameters
+            ...parse(this._location().search?.replace(/^\?/, '')), // Query parameters
         };
     }
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import assert, { deepEqual, strictEqual as same, throws } from 'assert';
 import route from '../../src/js';
 


### PR DESCRIPTION
This PR re-introduces the changes from d781b164b8f455730fe8a8b0cbf91f0f8cb55a73 in a way that I'm pretty certain won't break anything this time. It makes Ziggy's default build ES5-compatible.

**TLDR:** internal-only property getters like `get _location()` are mangled by Terser in a way that breaks them, so I changed our one internal getter to a regular method, `_location()`. It's now mangled correctly, so it's not publicly accessible but everything still works.

Closes #441, and closes #440 properly.

---

I'm not 100% sure what the root issue is here, but I'm pretty close and I'm sick enough of bundlers to stop playing with it now. This is what I've found so far:

JavaScript classes like Ziggy's `Router` are transpiled to a combination of objects with custom prototypes and functions to make them ES5 compatible, which looks kind of like this with microbundle's Babel setup:

```js
// Input

class Router {
    current() {
        return this._privateCurrent();
    }
    _privateCurrent() {
        return 'here';
    }
    location() {
        return this._location;
    }
    get _location() {
        return 'there';
    }
}

// Output (lots omitted)

  // ...
  var _proto = Router.prototype;

  _proto.current = function current() {
    return this._privateCurrent();
  };

  _proto._privateCurrent = function _privateCurrent() {
    return 'here';
  };

  _proto.location = function location() {
    return this._location;
  };

  _createClass(Router, [{
    key: "_location",
    get: function get() {
      return 'there';
    }
  }]);
  // ...
```

Notice that the methods become real properties of the Router object (because microbundle uses Babel's `loose` mode), while the `_location` getter is represented by an object with its key and a backing `get` function. Importantly, the properties and methods of the Router object are **not** represented by strings—`current` and `_privateCurrent` are real JavaScript tokens.

Terser, which `microbundle` runs our code through after Babel transpiles it, mangles properties and methods starting with `_` to shorten their names and make them inaccessible publicly. However this mangling obviously ignores strings, since mangling strings, like `'here'` or `'there'`, would destroy the functionality of the code.

Terser's output looks _kind of_ like this, but more optimized and a lot harder to read:

```js
p.current=function current(){return this.cur()}
p.cur=function cur(){return 'here'}
p.location=function location(){return this.loc}
c(Router, [{key:"_location",get:function get(){return 'there'}}])
```

`_privateCurrent` is mangled to `cur` everywhere it appears, shortening it's actual name and all calls to it, and the `location` method's internal `this._location` call is mangled to `this.loc`, but for the same reason that it doesn't mangle `'here'` and `'there'`, Terser **doesn't mangle the `"_location"` key** for that getter! Because its key is a string, `_location` doesn't get renamed properly, which is why `this.loc` doesn't exist when Ziggy later tries to call it from the `current()` method or `params` getter.

There might be a 'better' fix for this but it almost definitely involves setting up our own custom Rollup build, which I don't feel like doing this weekend 😅 for now, making `_location` a method solves this problem.