### PR TITLE
Add support for parameters inside individual route segments

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -60,6 +60,7 @@ export default class Route {
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
             .replace(/\/{[^}?]*\?}/g, '(\/[^/?]+)?')
+            .replace(/{[^}?]*\?}/g, '([^/?]+)?')
             .replace(/{[^}]+}/g, '[^/?]+')
             .replace(/^\w+:\/\//, '');
 

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -60,6 +60,9 @@ export default class Route {
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
             .replace(/\/{[^}?]*\?}/g, '(\/[^/?]+)?')
+            // TODO: the above line with the leading slash is necessary to pick up completely optional *segments*,
+            // like in `/pages/{subPage?}`, so that those are handled first before the more permissive patterns
+            // below, but there's probably a way to do this in one shot
             .replace(/{[^}?]*\?}/g, '([^/?]+)?')
             .replace(/{[^}]+}/g, '[^/?]+')
             .replace(/^\w+:\/\//, '');

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -246,7 +246,7 @@ export default class Router extends String {
 
         // Given part of a valid 'hydrated' URL containing all its parameter values,
         // a route template, and a delimiter, extract the parameters as an object
-        // E.g. dehydrate('events/{event}/{venue}', 'events/2/chicago', '/'); // { event: 2, venue: 'chicago' }
+        // E.g. dehydrate('events/2/chicago', 'events/{event}/{venue}', '/'); // { event: 2, venue: 'chicago' }
         const dehydrate = (hydrated, template = '', delimiter) => {
             const [values, segments] = [hydrated, template].map(s => s.split(delimiter));
 

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -253,8 +253,13 @@ export default class Router extends String {
             return segments.reduce((result, current, i) => {
                 // Only include template segments that are route parameters
                 // AND have a value present in the passed hydrated string
-                return /^{[^}?]+\??}$/.test(current) && values[i]
-                    ? { ...result, [current.replace(/^{|\??}$/g, '')]: values[i] }
+                return /{[^}?]+\??}/.test(current) && values[i]
+                    ? {
+                        ...result,
+                        [current.replace(/.*{|\??}.*/g, '')]: values[i]
+                            .replace(current.match(/^[^{]*/g), '')
+                            .replace(current.match(/[^}]*$/g), ''),
+                    }
                     : result;
             }, {});
         }

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -119,6 +119,10 @@ const defaultZiggy = {
             uri: 'optionalpage/{page?}',
             methods: ['GET', 'HEAD'],
         },
+        'pages.optionalExtension': {
+            uri: 'download/file{extension?}',
+            methods: ['GET', 'HEAD'],
+        },
         'pages': {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
@@ -619,6 +623,40 @@ describe('current()', () => {
         same(route().current('pages.optional', { page: '' }), true);
         same(route().current('pages.optional', { page: undefined }), true);
         same(route().current('pages.optional', { page: 'foo' }), false);
+    });
+
+    test('can check the current route name at a URL with a missing non-delimited optional parameter', () => {
+        global.window.location.pathname = '/download/file';
+
+        same(route().current(), 'pages.optionalExtension');
+        same(route().current('pages.optionalExtension', ''), true);
+        same(route().current('pages.optionalExtension*', ''), true);
+        same(route().current('pages.optionalExtension', ['']), true);
+        same(route().current('pages.optionalExtension*', ['']), true);
+        same(route().current('pages.optionalExtension', { extension: '' }), true);
+        same(route().current('pages.optionalExtension*', { extension: '' }), true);
+        same(route().current('pages.optionalExtension', { extension: '.html' }), false);
+        same(route().current('pages.optionalExtension*', { extension: '.pdf' }), false);
+    });
+
+    test('can check the current route name at a URL with a non-delimited optional parameter', () => {
+        global.window.location.pathname = '/download/file.html';
+
+        same(route().current(), 'pages.optionalExtension');
+        same(route().current('pages.optionalExtension', ''), false);
+        same(route().current('pages.optionalExtension*', ''), false);
+        same(route().current('pages.optionalExtension', '.html'), true);
+        same(route().current('pages.optionalExtension*', '.html'), true);
+        same(route().current('pages.optionalExtension', ['']), false);
+        same(route().current('pages.optionalExtension*', ['']), false);
+        same(route().current('pages.optionalExtension', ['.html']), true);
+        same(route().current('pages.optionalExtension*', ['.html']), true);
+        same(route().current('pages.optionalExtension', { extension: '' }), false);
+        same(route().current('pages.optionalExtension*', { extension: '' }), false);
+        same(route().current('pages.optionalExtension', { extension: '.pdf' }), false);
+        same(route().current('pages.optionalExtension*', { extension: '.pdf' }), false);
+        same(route().current('pages.optionalExtension', { extension: '.html' }), true);
+        same(route().current('pages.optionalExtension*', { extension: '.html' }), true);
     });
 
     test('can check the current route name with parameters on a URL with no parameters', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -123,6 +123,10 @@ const defaultZiggy = {
             uri: 'download/file{extension?}',
             methods: ['GET', 'HEAD'],
         },
+        'pages.requiredExtension': {
+            uri: 'strict-download/file{extension}',
+            methods: ['GET', 'HEAD'],
+        },
         'pages': {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
@@ -495,10 +499,16 @@ describe('route()', () => {
     });
 
     test('can generate a URL for a route with parameters inside individual segments', () => {
+        same(route('pages.requiredExtension', 'x'), 'https://ziggy.dev/strict-download/filex');
+        same(route('pages.requiredExtension', '.html'), 'https://ziggy.dev/strict-download/file.html');
+        same(route('pages.requiredExtension', { extension: '.pdf' }), 'https://ziggy.dev/strict-download/file.pdf');
+    });
+
+    test('can generate a URL for a route with optional parameters inside individual segments', () => {
         same(route('pages.optionalExtension'), 'https://ziggy.dev/download/file');
         same(route('pages.optionalExtension', '.html'), 'https://ziggy.dev/download/file.html');
         same(route('pages.optionalExtension', { extension: '.pdf' }), 'https://ziggy.dev/download/file.pdf');
-    })
+    });
 });
 
 describe('has()', () => {
@@ -629,6 +639,26 @@ describe('current()', () => {
         same(route().current('pages.optional', { page: '' }), true);
         same(route().current('pages.optional', { page: undefined }), true);
         same(route().current('pages.optional', { page: 'foo' }), false);
+    });
+
+    test('can check the current route name at a URL with a non-delimited parameter', () => {
+        global.window.location.pathname = '/strict-download/file.html';
+
+        same(route().current(), 'pages.requiredExtension');
+        same(route().current('pages.requiredExtension', ''), false);
+        same(route().current('pages.requiredExtension*', ''), false);
+        same(route().current('pages.requiredExtension', '.html'), true);
+        same(route().current('pages.requiredExtension*', '.html'), true);
+        same(route().current('pages.requiredExtension', ['']), false);
+        same(route().current('pages.requiredExtension*', ['']), false);
+        same(route().current('pages.requiredExtension', ['.html']), true);
+        same(route().current('pages.requiredExtension*', ['.html']), true);
+        same(route().current('pages.requiredExtension', { extension: '' }), false);
+        same(route().current('pages.requiredExtension*', { extension: '' }), false);
+        same(route().current('pages.requiredExtension', { extension: '.pdf' }), false);
+        same(route().current('pages.requiredExtension*', { extension: '.pdf' }), false);
+        same(route().current('pages.requiredExtension', { extension: '.html' }), true);
+        same(route().current('pages.requiredExtension*', { extension: '.html' }), true);
     });
 
     test('can check the current route name at a URL with a missing non-delimited optional parameter', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -493,6 +493,12 @@ describe('route()', () => {
          same(route('posts.show', [1, 2]), 'https://ziggy.dev/posts/1?2=');
          same(route('posts.show', ['my-first-post', 'foo', 'bar']), 'https://ziggy.dev/posts/my-first-post?foo=&bar=');
     });
+
+    test('can generate a URL for a route with parameters inside individual segments', () => {
+        same(route('pages.optionalExtension'), 'https://ziggy.dev/download/file');
+        same(route('pages.optionalExtension', '.html'), 'https://ziggy.dev/download/file.html');
+        same(route('pages.optionalExtension', { extension: '.pdf' }), 'https://ziggy.dev/download/file.pdf');
+    })
 });
 
 describe('has()', () => {


### PR DESCRIPTION
This PR adds support for parameters that don't match up evenly with a route's 'segments'—something like `download/file{extension?}`.

Previously, Ziggy assumed that all route parameters were also complete route segments. So, for example, `dehydrate('events/chicago', 'events/{venue}', '/')` would return `{ venue: 'chicago' }`, but something like `dehydrate('events/in-chicago', 'events/in-{venue}', '/')` would just fail, because the segment `in-{venue}` was not recognized as containing any parameters.

Now, instead of requiring a `/` before/after parameters, we just... don't. It was surprisingly simple! I think the whole 'delimiter' thing in the dehydration functions could eventually actually go away completely, since we don't really need to care about the delimiters at all if we can pick out parameters directly. I'll leave that for a future PR though to keep this one small and clear.

@adrianb93 any chance you can install this branch into your app and see if it works for you? I *think* you can just `npm install tighten/ziggy#jbk/optional-params-inside-segments`.

Closes #393.