### PR TITLE
Allow for abstract Model typed route params

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -3,6 +3,7 @@
 namespace Tightenco\Ziggy;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
@@ -159,7 +160,8 @@ class Ziggy implements JsonSerializable
                 $model = class_exists(Reflector::class)
                     ? Reflector::getParameterClassName($parameter)
                     : $parameter->getType()->getName();
-                $override = $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
+                $override = $model !== Model::class
+                    && $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
 
                 // Avoid booting this model if it doesn't override the default route key name
                 $bindings[$parameter->getName()] = $override ? app($model)->getRouteKeyName() : 'id';

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -3,11 +3,11 @@
 namespace Tightenco\Ziggy;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use JsonSerializable;
+use ReflectionClass;
 use ReflectionMethod;
 
 class Ziggy implements JsonSerializable
@@ -160,7 +160,7 @@ class Ziggy implements JsonSerializable
                 $model = class_exists(Reflector::class)
                     ? Reflector::getParameterClassName($parameter)
                     : $parameter->getType()->getName();
-                $override = $model !== Model::class
+                $override = (new ReflectionClass($model))->isInstantiable()
                     && $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
 
                 // Avoid booting this model if it doesn't override the default route key name

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -183,6 +183,23 @@ class RouteModelBindingTest extends TestCase
         $this->assertTrue(User::$wasBooted);
         $this->assertFalse(Tag::$wasBooted);
     }
+
+    /** @test */
+    public function can_handle_abstract_classes_in_route_model_bindings()
+    {
+        app('router')->get('models/{model}', function (Model $model) {
+            return '';
+        })->name('models');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->assertSame([
+            'uri' => 'models/{model}',
+            'methods' => ['GET', 'HEAD'],
+            'bindings' => [
+                'model' => 'id',
+            ],
+        ], (new Ziggy)->toArray()['routes']['models']);
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
This prevents an `Illuminate\Contracts\Container\BindingResolutionException` with message `Target [Illuminate\Database\Eloquent\Model] is not instantiable.` when the route parameter is typed as the abstract `Illuminate\Database\Eloquent\Model`:

```
use Illuminate\Database\Eloquent\Model;

class MyController extends Controller
{
    public function create(Model $model)
    {
        //
    }
}
```