### PR TITLE
Treat all parameters not matching a named route segment as query params

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -178,7 +178,7 @@ export default class Router extends String {
 
         return {
             ...this._defaults(route),
-            ...this._substituteBindings(params, route.bindings),
+            ...this._substituteBindings(params, route),
         };
     }
 
@@ -201,17 +201,17 @@ export default class Router extends String {
      * Substitute Laravel route model bindings in the given parameters.
      *
      * @example
-     * _substituteBindings({ post: { id: 4, slug: 'hello-world', title: 'Hello, world!' } }, { post: 'slug' }); // { post: 'hello-world' }
+     * _substituteBindings({ post: { id: 4, slug: 'hello-world', title: 'Hello, world!' } }, { bindings: { post: 'slug' } }); // { post: 'hello-world' }
      *
      * @param {Object} params - Route parameters.
-     * @param {Object} bindings - Route model bindings.
+     * @param {Object} route - Route definition.
      * @return {Object} Normalized route parameters.
      */
-    _substituteBindings(params, bindings = {}) {
+    _substituteBindings(params, { bindings, parameterSegments }) {
         return Object.entries(params).reduce((result, [key, value]) => {
-            // If the value isn't an object, or if it's an object of explicit query
-            // parameters, there's nothing to substitute so we return it as-is
-            if (!value || typeof value !== 'object' || Array.isArray(value) || key === '_query') {
+            // If the value isn't an object, if it's an object of explicit query parameters, or if the key
+            // is not a named route parameter, there's nothing to substitute so we return it as-is
+            if (!value || typeof value !== 'object' || Array.isArray(value) || key === '_query' || !parameterSegments.some(({ name }) => name === key)) {
                 return { ...result, [key]: value };
             }
 

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -209,9 +209,9 @@ export default class Router extends String {
      */
     _substituteBindings(params, { bindings, parameterSegments }) {
         return Object.entries(params).reduce((result, [key, value]) => {
-            // If the value isn't an object, if it's an object of explicit query parameters, or if the key
-            // is not a named route parameter, there's nothing to substitute so we return it as-is
-            if (!value || typeof value !== 'object' || Array.isArray(value) || key === '_query' || !parameterSegments.some(({ name }) => name === key)) {
+            // If the value isn't an object, or if the key isn't a named route parameter,
+            // there's nothing to substitute so we return it as-is
+            if (!value || typeof value !== 'object' || Array.isArray(value) || !parameterSegments.some(({ name }) => name === key)) {
                 return { ...result, [key]: value };
             }
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -489,6 +489,15 @@ describe('route()', () => {
          same(route('posts.show', [1, 2]), 'https://ziggy.dev/posts/1?2=');
          same(route('posts.show', ['my-first-post', 'foo', 'bar']), 'https://ziggy.dev/posts/my-first-post?foo=&bar=');
     });
+
+    test("can automatically append object with only 'extra' parameters to query", () => {
+        // Route has no parameters, the entire parameters object is 'extra' and should be used as the query string
+        same(route('hosting-contacts.index', { filter: { name: 'Dwyer' } }), 'https://ziggy.dev/hosting-contacts?filter[name]=Dwyer');
+    });
+
+    test("can append 'extra' object parameter to query", () => {
+        same(route('posts.show', { post: 2, filter: { name: 'Dwyer' } }), 'https://ziggy.dev/posts/2?filter[name]=Dwyer');
+    });
 });
 
 describe('has()', () => {


### PR DESCRIPTION
This PR assumes that any object keys/values passed into `route()` as parameters that do not match any named route segments are treated as query parameters.

**Before**

```js
// route 'home' at `/home`

route('home', ['foo']); // `/home?foo=`
route('home', { foo: 'bar' }); // `/home?foo=bar`
route('home', { _query: { foo: { bar: 'baz' } } }); // `/home?foo[bar]=baz`

route('home', { foo: { bar: 'baz' } }); // error
```

That last example causes an error because Ziggy sees that the value of the `foo` parameter passed in is an object, so it expects either an `id` key in that object or a key matching the binding for the `foo` route parameter—but there is no `foo` route parameter.

**After**

```js
// route 'home' at `/home`

route('home', ['foo']); // `/home?foo=`
route('home', { foo: 'bar' }); // `/home?foo=bar`
route('home', { _query: { foo: { bar: 'baz' } } }); // `/home?foo[bar]=baz`

route('home', { foo: { bar: 'baz' } }); // `/home?foo[bar]=baz`
```

Closes #450.