### PR TITLE
Fix Octane caching issue

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -5,28 +5,24 @@ namespace Tightenco\Ziggy;
 class BladeRouteGenerator
 {
     public static $generated;
-    public static $payload;
 
     public function generate($group = null, $nonce = null)
     {
-        if (! static::$payload) {
-            static::$payload = new Ziggy($group);
-        }
+        $payload = new Ziggy($group);
 
         $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (static::$generated) {
-            return $this->generateMergeJavascript(json_encode(static::$payload->toArray()['routes']), $nonce);
+            return $this->generateMergeJavascript(json_encode($payload->toArray()['routes']), $nonce);
         }
 
-        $ziggy = static::$payload->toJson();
         $routeFunction = $this->getRouteFunction();
 
         static::$generated = true;
 
         return <<<HTML
 <script type="text/javascript"{$nonce}>
-    const Ziggy = {$ziggy};
+    const Ziggy = {$payload->toJson()};
 
     $routeFunction
 </script>

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -14,7 +14,6 @@ class Ziggy implements JsonSerializable
 {
     protected static $cache;
 
-    protected $port;
     protected $url;
     protected $group;
     protected $routes;
@@ -24,7 +23,6 @@ class Ziggy implements JsonSerializable
         $this->group = $group;
 
         $this->url = rtrim($url ?? url('/'), '/');
-        $this->port = parse_url($this->url)['port'] ?? null;
 
         if (! static::$cache) {
             static::$cache = $this->nameKeyedRoutes();
@@ -131,7 +129,7 @@ class Ziggy implements JsonSerializable
     {
         return [
             'url' => $this->url,
-            'port' => $this->port,
+            'port' => parse_url($this->url)['port'] ?? null,
             'defaults' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -12,6 +12,8 @@ use ReflectionMethod;
 
 class Ziggy implements JsonSerializable
 {
+    protected static $cache;
+
     protected $port;
     protected $url;
     protected $group;
@@ -24,7 +26,16 @@ class Ziggy implements JsonSerializable
         $this->url = rtrim($url ?? url('/'), '/');
         $this->port = parse_url($this->url)['port'] ?? null;
 
-        $this->routes = $this->nameKeyedRoutes();
+        if (! static::$cache) {
+            static::$cache = $this->nameKeyedRoutes();
+        }
+
+        $this->routes = static::$cache;
+    }
+
+    public static function clearRoutes()
+    {
+        static::$cache = null;
     }
 
     private function applyFilters($group)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,18 @@ namespace Tests;
 use Closure;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use PHPUnit\Framework\Constraint\StringContains;
+use Tightenco\Ziggy\Ziggy;
 use Tightenco\Ziggy\ZiggyServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
+    protected function tearDown(): void
+    {
+        Ziggy::clearRoutes();
+
+        parent::tearDown();
+    }
+
     protected function getPackageProviders($app)
     {
         return [ZiggyServiceProvider::class];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,13 @@ use Tightenco\Ziggy\ZiggyServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
+    public static function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
+    {
+        $constraint = new StringContains($needle, false);
+
+        static::assertThat($haystack, $constraint, $message);
+    }
+
     protected function tearDown(): void
     {
         Ziggy::clearRoutes();
@@ -34,12 +41,5 @@ class TestCase extends OrchestraTestCase
         return function () {
             return '';
         };
-    }
-
-    public static function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
-    {
-        $constraint = new StringContains($needle, false);
-
-        static::assertThat($haystack, $constraint, $message);
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -9,13 +9,6 @@ use Tightenco\Ziggy\Ziggy;
 
 class BladeRouteGeneratorTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        BladeRouteGenerator::$payload = null;
-
-        parent::tearDown();
-    }
-
     /** @test */
     public function can_resolve_generator_from_container()
     {
@@ -126,7 +119,6 @@ class BladeRouteGeneratorTest extends TestCase
         $this->assertArrayHasKey('posts.show', $ziggy['routes']);
 
         BladeRouteGenerator::$generated = false;
-        BladeRouteGenerator::$payload = null;
         $output = (new BladeRouteGenerator)->generate(['guest', 'admin']);
         $ziggy = json_decode(Str::after(Str::before($output, ";\n\n"), ' = '), true);
 

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -491,4 +491,15 @@ class ZiggyTest extends TestCase
         $response->assertSuccessful();
         $this->assertSame((new Ziggy)->toJson(), $response->getContent());
     }
+
+    /** @test */
+    public function can_cache_compiled_route_list_internally_on_repeated_instantiations()
+    {
+        $routes = (new Ziggy)->toArray()['routes'];
+
+        app('router')->get('/users', $this->noop())->name('users.index');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->assertSame($routes, (new Ziggy)->toArray()['routes']);
+    }
 }


### PR DESCRIPTION
My original PR to improve Ziggy's performance on Octane, #417, turned out to be a bit overzealous—it cached the entire `Ziggy` instance, including the base URL and any configured groups. While the routes don't change between requests, the app URL can, as described in #457.

Another issue I noticed looking into this is that the `$group` passed to Ziggy can also change, not only between requests but even in the same request if the Blade directive is used in different places, so we can't cache that either.

This PR reverts #417 and tackles caching in a slightly different way, doing it inside the `Ziggy` class and only caching the list of named routes and nothing else.

Closes #457.