### PR TITLE
fix: catch undefined global Ziggy

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -14,7 +14,7 @@ export default class Router extends String {
     constructor(name, params, absolute = true, config) {
         super();
 
-        this._config = config ?? Ziggy ?? globalThis?.Ziggy;
+        this._config = config ?? (typeof Ziggy !== 'undefined' ? Ziggy : globalThis?.Ziggy);
         this._config = { ...this._config, absolute };
 
         if (name) {


### PR DESCRIPTION
In case Ziggy is not defined at all as a variable, the current code dumps because `Ziggy is not defined`.