### PR TITLE
Fix name transformation in current()

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -83,7 +83,7 @@ export default class Router extends String {
 
         // Test the passed name against the current route, matching some
         // basic wildcards, e.g. passing `events.*` matches `events.show`
-        const match = new RegExp(`^${name.replace('.', '\\.').replace('*', '.*')}$`).test(current);
+        const match = new RegExp(`^${name.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`).test(current);
 
         if ([null, undefined].includes(params) || !match) return match;
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -58,6 +58,13 @@ const defaultZiggy = {
             uri: '{locale}/posts/{post}',
             methods: ['PUT', 'PATCH'],
         },
+        'events.venues-index': {
+            uri: 'events/{event}/venues-index',
+            methods: ['GET', 'HEAD'],
+            bindings: {
+                event: 'id',
+            },
+        },
         'events.venues.index': {
             uri: 'events/{event}/venues',
             methods: ['GET', 'HEAD'],
@@ -879,6 +886,25 @@ describe('current()', () => {
         global.window.location.pathname = '/events/1/venues/';
 
         same(route().current(), 'events.venues.index');
+    });
+
+    test('does not match similiar named routes', () => {
+        global.window.location.pathname = '/events/1/venues';
+
+        same(route().current('events.venues-index'), false);
+        same(route().current('events.venues.index'), true);
+
+        global.window.location.pathname = '/events/1/venues-index';
+
+        same(route().current('events.venues-index'), true);
+        same(route().current('events.venues.index'), false);
+    });
+
+    test('does not match similiar named routes with wildcards', () => {
+        global.window.location.pathname = '/events/1/venues-index';
+
+        same(route().current('events.venues-index'), true);
+        same(route().current('events.venues.*'), false);
     });
 
     test('can get the current route name without window', () => {


### PR DESCRIPTION
Fixes dot and wildcard replace to match all occurrences of , and * .

Without the fix `current('event.venue.index')` would match `event.venue-index` since only the first dot gets escaped.
Other Example: `current('event.venue.*')` would match `event.venue.index` and `event.venue-soon.index`.

This PR should fix that.

Tests are also provided.