### PR TITLE
Add `useRoute()` React hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,22 +387,46 @@ Now you can use `route()` anywhere in your Vue components and templates, like so
 
 #### React
 
-To use Ziggy with React, start by importing the `route()` function and your Ziggy config. Because the Ziggy config object is not available globally in this setup, you'll have to pass it to the `route()` function manually:
+Ziggy includes a `useRoute()` hook to make it easy to use the `route()` helper in your React app:
+
+```jsx
+import React from 'react';
+import { useRoute } from 'ziggy-js';
+import { Ziggy } from './ziggy';
+
+export default function PostsLink() {
+    const route = useRoute(Ziggy);
+
+    return (
+        <a href={route('posts.index')}>Posts</a>
+    );
+}
+```
+
+If you make the `Ziggy` config object available globally, you can use the `useRoute()` hook without importing and passing Ziggy's configuration to it every time:
 
 ```js
 // app.js
-
-import route from 'ziggy';
 import { Ziggy } from './ziggy';
 
-// ...
-
-route('home', undefined, undefined, Ziggy);
+globalThis.Ziggy = Ziggy;
 ```
 
-We're working on adding a Hook to Ziggy to make this cleaner, but for now make sure you pass the configuration object as the fourth argument to the `route()` function as shown above.
+```jsx
+// PostsLink.js
+import React from 'react';
+import { useRoute } from 'ziggy-js';
 
-> Note: If you include the `@routes` Blade directive in your views, the `route()` helper will already be available globally, including in your React app, so you don't need to import `route` or `Ziggy` anywhere.
+export default function PostsLink() {
+    const route = useRoute();
+
+    return (
+        <a href={route('posts.index')}>Posts</a>
+    );
+}
+```
+
+> Note: If you include the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object anywhere or make it global manually.
 
 #### SPAs or separate repos
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Now you can use `route()` anywhere in your Vue components and templates, like so
 Ziggy includes a `useRoute()` hook to make it easy to use the `route()` helper in your React app:
 
 ```jsx
+// PostsLink.js
 import React from 'react';
 import { useRoute } from 'ziggy-js';
 import { Ziggy } from './ziggy';
@@ -397,9 +398,7 @@ import { Ziggy } from './ziggy';
 export default function PostsLink() {
     const route = useRoute(Ziggy);
 
-    return (
-        <a href={route('posts.index')}>Posts</a>
-    );
+    return <a href={route('posts.index')}>Posts</a>;
 }
 ```
 
@@ -408,7 +407,6 @@ If you make the `Ziggy` config object available globally, you can use the `useRo
 ```js
 // app.js
 import { Ziggy } from './ziggy';
-
 globalThis.Ziggy = Ziggy;
 ```
 
@@ -420,13 +418,11 @@ import { useRoute } from 'ziggy-js';
 export default function PostsLink() {
     const route = useRoute();
 
-    return (
-        <a href={route('posts.index')}>Posts</a>
-    );
+    return <a href={route('posts.index')}>Posts</a>;
 }
 ```
 
-> Note: If you include the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object anywhere or make it global manually.
+> Note: If you include the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object or make it global with `globalThis.Ziggy = Ziggy`.
 
 #### SPAs or separate repos
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ export default function PostsLink() {
 }
 ```
 
-> Note: If you include the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object or make it global with `globalThis.Ziggy = Ziggy`.
+> Note: If you include the `@routes` Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the `Ziggy` config object or make it available globally with `globalThis.Ziggy = Ziggy`—you can use the `useRoute()` hook exactly as shown in the `PostsLink.js` example directly above, without any other setup.
 
 #### SPAs or separate repos
 

--- a/package.json
+++ b/package.json
@@ -42,11 +42,13 @@
     "scripts": {
         "build": "microbundle --name route --format modern,es,umd --external none --no-sourcemap",
         "build:vue": "microbundle --entry src/js/vue.js --output dist/vue.js --name ZiggyVue --format modern,es,umd --external none --no-sourcemap",
+        "build:react": "microbundle --entry src/js/react.js --output dist/react.js --name ZiggyReact --format modern,es,umd --external none --no-sourcemap",
         "watch": "npm run build watch",
         "build:npm": "microbundle --name route --format modern,es,umd --no-sourcemap",
         "build:npm:vue": "microbundle --entry src/js/vue.js --output dist/vue.js --name ZiggyVue --format modern,es,umd --no-sourcemap",
+        "build:npm:react": "microbundle --entry src/js/react.js --output dist/react.js --name ZiggyReact --format modern,es,umd --no-sourcemap",
         "test": "jest --verbose",
-        "prepublishOnly": "npm run build:npm && npm run build:npm:vue"
+        "prepublishOnly": "npm run build:npm && npm run build:npm:vue && npm run build:npm:react"
     },
     "mangle": {
         "regex": "^_(?!query)"

--- a/src/js/react.js
+++ b/src/js/react.js
@@ -1,0 +1,9 @@
+import route from './index.js';
+
+export const useRoute = (defaultConfig) => {
+    if (!defaultConfig && !globalThis.Ziggy && typeof Ziggy === 'undefined') {
+        throw new Error('Ziggy error: missing configuration. Ensure that a `Ziggy` variable is defined globally or pass a config object into the useRoute hook.');
+    }
+
+    return (name, params, absolute, config = defaultConfig) => route(name, params, absolute, config);
+};

--- a/src/js/react.js
+++ b/src/js/react.js
@@ -2,7 +2,7 @@ import route from './index.js';
 
 export const useRoute = (defaultConfig) => {
     if (!defaultConfig && !globalThis.Ziggy && typeof Ziggy === 'undefined') {
-        throw new Error('Ziggy error: missing configuration. Ensure that a `Ziggy` variable is defined globally or pass a config object into the useRoute hook.');
+        throw new Error('Ziggy error: missing configuration. Ensure that a `Ziggy` variable is defined globally or pass a config object into `useRoute()`.');
     }
 
     return (name, params, absolute, config = defaultConfig) => route(name, params, absolute, config);


### PR DESCRIPTION
Adds a `useRoute()` React hook. If the `Ziggy` config object is available globally, usage is as simple as:

```jsx
import { useRoute } from 'ziggy-js';

export default () => {
    const route = useRoute();

    return (
        <a href={route('home')}>Home</a>
    );
};
```

Closes #327.