### PR TITLE
Add support for not encoding slashes in wildcard last parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 vendor/
+*.cache
 *.log
 composer.lock
 phpunit.xml

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -109,7 +109,7 @@ class Ziggy implements JsonSerializable
 
         return $routes->merge($fallbacks)
             ->map(function ($route) use ($bindings) {
-                return collect($route)->only(['uri', 'methods'])
+                return collect($route)->only(['uri', 'methods', 'wheres'])
                     ->put('domain', $route->domain())
                     ->put('bindings', $bindings[$route->getName()] ?? [])
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -11,6 +11,7 @@ export default class Route {
         this.name = name;
         this.definition = definition;
         this.bindings = definition.bindings ?? {};
+        this.wheres = definition.wheres ?? {};
         this.config = config;
     }
 
@@ -83,6 +84,10 @@ export default class Route {
             // If the parameter is missing but is not optional, throw an error
             if ([null, undefined].includes(params[segment]) && this.parameterSegments.find(({ name }) => name === segment).required) {
                 throw new Error(`Ziggy error: '${segment}' parameter is required for route '${this.name}'.`)
+            }
+
+            if (this.parameterSegments[this.parameterSegments.length - 1].name === segment && this.wheres[segment] === '.*') {
+                return params[segment] ?? '';
             }
 
             return encodeURIComponent(params[segment] ?? '');

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class CommandRouteGeneratorTest extends TestCase
@@ -44,6 +43,7 @@ class CommandRouteGeneratorTest extends TestCase
     {
         $router = app('router');
         $router->get('posts/{post}/comments', $this->noop())->name('postComments.index');
+        $router->get('slashes/{slug}', $this->noop())->where('slug', '.*')->name('slashes');
         $router->getRoutes()->refreshNameLookups();
 
         Artisan::call('ziggy:generate');
@@ -83,6 +83,7 @@ class CommandRouteGeneratorTest extends TestCase
         config(['ziggy.except' => ['admin.*']]);
         $router = app('router');
         $router->get('posts/{post}/comments', $this->noop())->name('postComments.index');
+        $router->get('slashes/{slug}', $this->noop())->where('slug', '.*')->name('slashes');
         $router->get('admin', $this->noop())->name('admin.dashboard'); // Excluded, should NOT be present in file
         $router->getRoutes()->refreshNameLookups();
 

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -312,6 +312,27 @@ class ZiggyTest extends TestCase
     }
 
     /** @test */
+    public function can_include_wheres()
+    {
+        app('router')->post('slashes/{slug}', function () {
+            return response()->json(new Ziggy);
+        })->where('slug', '.*')->name('slashes');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->post('http://ziggy.dev/slashes/foo/bar')
+            ->assertJson([
+                'routes' => [
+                    'slashes' => [
+                        'uri' => 'slashes/{slug}',
+                        'wheres' => [
+                            'slug' => '.*',
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    /** @test */
     public function can_include_only_middleware_set_in_config()
     {
         config(['ziggy.middleware' => ['auth']]);
@@ -396,6 +417,9 @@ class ZiggyTest extends TestCase
         $expected['fallback'] = [
             'uri' => '{fallbackPlaceholder}',
             'methods' => ['GET', 'HEAD'],
+            'wheres' => [
+                'fallbackPlaceholder' => '.*',
+            ],
         ];
 
         $this->assertSame($expected, $routes);

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]},"slashes":{"uri":"slashes\/{slug}","methods":["GET","HEAD"],"wheres":{"slug":".*"}}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     Object.assign(Ziggy.routes, window.Ziggy.routes);

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -16,7 +16,7 @@ const defaultZiggy = {
     port: null,
     defaults: { locale: 'en' },
     routes: {
-        'home': {
+        home: {
             uri: '/',
             methods: ['GET', 'HEAD'],
         },
@@ -96,11 +96,11 @@ const defaultZiggy = {
             uri: 'subscribers/{subscriber}/conversations/{type}/{conversation_id?}',
             methods: ['GET', 'HEAD'],
         },
-        'optional': {
+        optional: {
             uri: 'optional/{id}/{slug?}',
             methods: ['GET', 'HEAD'],
         },
-        'optionalId': {
+        optionalId: {
             uri: 'optionalId/{type}/{id?}',
             methods: ['GET', 'HEAD'],
         },
@@ -134,9 +134,16 @@ const defaultZiggy = {
             uri: 'strict-download/file{extension}',
             methods: ['GET', 'HEAD'],
         },
-        'pages': {
+        pages: {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
+        },
+        slashes: {
+            uri: 'slashes/{encoded}/{slug}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                slug: '.*',
+            },
         },
     },
 };
@@ -527,7 +534,7 @@ describe('route()', () => {
     });
 
     test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
-        same(route('optional', ['1', 'foo/bar']), 'https://ziggy.dev/optional/1/foo/bar')
+        same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four')
     });
 });
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -525,6 +525,10 @@ describe('route()', () => {
         same(route('pages.optionalExtension', '.html'), 'https://ziggy.dev/download/file.html');
         same(route('pages.optionalExtension', { extension: '.pdf' }), 'https://ziggy.dev/download/file.pdf');
     });
+
+    test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
+        same(route('optional', ['1', 'foo/bar']), 'https://ziggy.dev/optional/1/foo/bar')
+    });
 });
 
 describe('has()', () => {


### PR DESCRIPTION
Laravel allows optionally not encoding slashes in the last route parameter by specifying a wildcard regex pattern (https://laravel.com/docs/8.x/routing#parameters-encoded-forward-slashes), but Ziggy didn't know about these 'wheres' and would always encode everything.

This PR updates Ziggy to skip URI-encoding the very last named route parameter if it has a wildcard `where` condition.

@just-tom I believe this will solve your issue. Closes #490.