### PR TITLE
Handle enums in route model bindings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,8 @@
 <phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Ziggy Tests">
-            <directory suffix="Test.php">./tests</directory>
+            <directory suffix="Test.php">./tests/Unit</directory>
+            <directory suffix="Test.php" phpVersion="8.1" phpVersionOperator=">=">./tests/Unit81</directory>
         </testsuite>
     </testsuites>
     <php>

--- a/tests/Unit81/RouteModelBindingTest.php
+++ b/tests/Unit81/RouteModelBindingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit81;
+
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Tests\TestCase;
+use Tightenco\Ziggy\Ziggy;
+
+class RouteModelBindingTest extends TestCase
+{
+    /** @test */
+    public function can_handle_enums_in_route_model_bindings()
+    {
+        app('router')->get('sections/{section}', function (Section $section) {
+            return '';
+        })->name('sections');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->assertSame([
+            'uri' => 'sections/{section}',
+            'methods' => ['GET', 'HEAD'],
+            'bindings' => [
+                'section' => 'section',
+            ],
+        ], (new Ziggy)->toArray()['routes']['sections']);
+    }
+
+    /** @test */
+    public function uses_default_route_key_name_for_enums_without_cases()
+    {
+        app('router')->get('types/{type}', function (Type $type) {
+            return '';
+        })->name('types');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->assertSame([
+            'uri' => 'types/{type}',
+            'methods' => ['GET', 'HEAD'],
+            'bindings' => [
+                'type' => 'id',
+            ],
+        ], (new Ziggy)->toArray()['routes']['types']);
+    }
+}
+
+enum Section: string implements UrlRoutable
+{
+    case First = 'first';
+    case Second = 'second';
+    case Third = 'third';
+
+    public function getRouteKey(): string
+    {
+        return $this->value;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'section';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?self
+    {
+        return self::tryFrom($value);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field)
+    {
+        return null;
+    }
+}
+
+enum Type implements UrlRoutable
+{
+    public function getRouteKey()
+    {
+    }
+
+    public function getRouteKeyName()
+    {
+    }
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field)
+    {
+    }
+}


### PR DESCRIPTION
Closes #499.

Support resolving route key names for route parameters using any [`UrlRoutable`](https://laravel.com/api/8.x/Illuminate/Contracts/Routing/UrlRoutable.html) implementation, e.g. [enum](https://wiki.php.net/rfc/enumerations).

Current implementation causes an error using the `@routes` Blade directive, because enum may not include `__construct` so Laravel is not able to resolve it automatically from the container using the `app()` helper function in `Ziggy.php`.

The proposed changes are not perfect, but do not require PHP 8.1 and are fully backward compatible 🤷🏻
I am open to any suggestions.