### PR TITLE
still encode other characters in last parameter

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -87,7 +87,7 @@ export default class Route {
             }
 
             if (this.parameterSegments[this.parameterSegments.length - 1].name === segment && this.wheres[segment] === '.*') {
-                return params[segment] ?? '';
+                return encodeURIComponent(params[segment] ?? '').replaceAll('%2F', '/');
             }
 
             return encodeURIComponent(params[segment] ?? '');

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -534,7 +534,8 @@ describe('route()', () => {
     });
 
     test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
-        same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four')
+        same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four');
+        same(route('slashes', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one%2Ftwo/Fun%26Games/venues');
     });
 });
 


### PR DESCRIPTION
version 1.4.3 added the ability to use forward slashes on the last parameter when the user has configured a route to accept any value on it.

But other special characters should still be URL encoded.

This PR:

- Use `encodeURIComponent` to encode other characters than `/` in the last parameter
- Add a test assertion that fails without this PR's code change and passes afterwards
