### PR TITLE
[Vue] Make the global mixin property configurable and add doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ import App from './App';
 
 createApp(App).use(ZiggyVue, Ziggy);
 
-// Vue 2
+// Vue 2 & 3
 import Vue from 'vue'
 import { ZiggyVue } from 'ziggy';
 import { Ziggy } from './ziggy';
@@ -370,6 +370,49 @@ Now you can use `route()` anywhere in your Vue components and templates, like so
 
 ```html
 <a class="nav-link" :href="route('home')">Home</a>
+```
+
+To use it in a vue 3 setup function
+
+```js
+import { inject } from 'vue';
+
+export default {
+  setup() {
+    const route = inject('route');
+    // You don't need to export it to the component as this is already done by the plugin
+    return {}
+  },
+}
+```
+
+If the route global method conflicts with other libraries because it declares a route prop or route method internally (which is quite common) it is recommended to rename the global property, you can do so with the third parameter of the plugin.  
+
+```js
+Vue.use(ZiggyVue, Ziggy, '$route')
+```
+
+Don't forget to replace all your usages of `route` with your new name (`$route` in the previous example)
+
+Or if you don't want to install the vue global method
+
+```js
+Vue.use(ZiggyVue, Ziggy, 'route', false)
+```
+
+In which case you will need to manually import route into your components
+
+```js
+import { inject } from 'vue';
+
+export default {
+  setup() {
+    const route = inject('route');
+    return {
+        route
+    }
+  },
+}
 ```
 
 #### React

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -1,17 +1,16 @@
 import route from './index.js';
 
 export const ZiggyVue = {
-    install: (v, options) => {
+    install: (v, options, property = 'route', exposeGlobal = true) => {
         const r = (name, params, absolute, config = options) => route(name, params, absolute, config);
-
-        v.mixin({
-            methods: {
-                route: r,
-            },
-        });
-
-        if (parseInt(v.version) > 2) {
-            v.provide('route', r);
+        if (exposeGlobal) {
+            v.config && (v.config.globalProperties[property] = r);
+            v.mixin && v.mixin({
+                methods: {
+                    [property]: r,
+                },
+            });
         }
+        v.provide && v.provide(property, r);
     },
 };


### PR DESCRIPTION
Using 'route' as a global mixin name is a very bad idea as it conflicts with a lot of plugins out there (since it's a global mixin and just using a prop named 'route' anywhere would just result in a conflict)

It's usually recommended to prefix it with '$' for global mixins so that it wouldn't conflict with props or methods

To not make it a breaking change I just propose to make it configurable in the plugin options so that it can be changed if a conflict occurs
