### PR TITLE
fix: updated the route matching logic to take the wheres into account (#513)

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -1,3 +1,5 @@
+import {parse} from "qs";
+
 /**
  * A Laravel route. This class represents one route and its configuration and metadata.
  */
@@ -52,7 +54,7 @@ export default class Route {
      * Get whether this route's template matches the given URL.
      *
      * @param {String} url - URL to check.
-     * @return {Boolean} Whether this route matches.
+     * @return {Array|false} If this route matches, returns the matched parameters.
      */
     matchesUrl(url) {
         if (!this.definition.methods.includes('GET')) return false;
@@ -60,15 +62,15 @@ export default class Route {
         // Transform the route's template into a regex that will match a hydrated URL,
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
-            .replace(/\/{[^}?]*\?}/g, '(\/[^/?]+)?')
-            // TODO: the above line with the leading slash is necessary to pick up completely optional *segments*,
-            // like in `/pages/{subPage?}`, so that those are handled first before the more permissive patterns
-            // below, but there's probably a way to do this in one shot
-            .replace(/{[^}?]*\?}/g, '([^/?]+)?')
-            .replace(/{[^}]+}/g, '[^/?]+')
+            .replace(/(\/?){([^}?]*)(\??)}/g, (_, slash, segment, optional) => {
+              const regex = '(?<'+segment+'>' + (this.wheres[segment] || '[^/?]+') + ')';
+              return optional ? '(' + slash + regex + ')?' : slash + regex
+            })
             .replace(/^\w+:\/\//, '');
 
-        return new RegExp(`^${pattern}$`).test(url.replace(/\/+$/, '').split('?').shift());
+        const split = url.replace(/^\w+:\/\//, '').split('?');
+        const matches = new RegExp(`^${pattern}/?$`).exec(split[0]);
+        return matches ? {params: matches.groups, query: parse(split[1])} : false;
     }
 
     /**
@@ -78,16 +80,24 @@ export default class Route {
      * @return {String}
      */
     compile(params) {
-        if (!this.parameterSegments.length) return this.template;
+        const segments = this.parameterSegments;
+        if (!segments.length) {
+            return this.template;
+        }
 
-        return this.template.replace(/{([^}?]+)\??}/g, (_, segment) => {
+        return this.template.replace(/{([^}?]+)(\??)}/g, (_, segment, optional) => {
             // If the parameter is missing but is not optional, throw an error
-            if ([null, undefined].includes(params[segment]) && this.parameterSegments.find(({ name }) => name === segment).required) {
+            if (!optional && [null, undefined].includes(params[segment])) {
                 throw new Error(`Ziggy error: '${segment}' parameter is required for route '${this.name}'.`)
             }
 
-            if (this.parameterSegments[this.parameterSegments.length - 1].name === segment && this.wheres[segment] === '.*') {
+            if (segments[segments.length - 1].name === segment && this.wheres[segment] === '.*') {
                 return encodeURIComponent(params[segment] ?? '').replaceAll('%2F', '/');
+            }
+
+            if (this.wheres[segment] &&
+                !new RegExp('^'+(optional ? '(' + this.wheres[segment] + ')?' : this.wheres[segment])+'$').test(params[segment] ?? '')) {
+                throw new Error(`Ziggy error: '${segment}' parameter does not match required format '${this.wheres[segment]}' for route '${this.name}'.`)
             }
 
             return encodeURIComponent(params[segment] ?? '');

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -1,4 +1,4 @@
-import { parse, stringify } from 'qs';
+import { stringify } from 'qs';
 import Route from './Route';
 
 /**
@@ -6,10 +6,10 @@ import Route from './Route';
  */
 export default class Router extends String {
     /**
-     * @param {String} name - Route name.
-     * @param {(String|Number|Array|Object)} params - Route parameters.
-     * @param {Boolean} absolute - Whether to include the URL origin.
-     * @param {Object} config - Ziggy configuration.
+     * @param {String} [name] - Route name.
+     * @param {(String|Number|Array|Object)} [params] - Route parameters.
+     * @param {Boolean} [absolute] - Whether to include the URL origin.
+     * @param {Object} [config] - Ziggy configuration.
      */
     constructor(name, params, absolute = true, config) {
         super();
@@ -37,6 +37,10 @@ export default class Router extends String {
      * @return {String}
      */
     toString() {
+        if (!this._params) {
+            return window.location.toString();
+        }
+
         // Get parameters that don't correspond to any route segments to append them to the query
         const unhandled = Object.keys(this._params)
             .filter((key) => !this._route.parameterSegments.some(({ name }) => name === key))
@@ -53,6 +57,37 @@ export default class Router extends String {
     }
 
     /**
+     * Find the first route that matches the URL
+     *
+     * @param {string} [url] The url to resolve, defaults to the current url
+     * @returns {{name: string, params: Object, query: Object, route: Route}}
+     */
+    unresolve(url) {
+        if (!url) {
+            url = this._currentUrl();
+        } else if (this._config.absolute && url.startsWith('/')) {
+            const loc = this._location();
+            url += loc.host;
+        }
+        let matchedParams = {};
+        const [name, route] = Object.entries(this._config.routes).find(
+          (entry) => (matchedParams = new Route(entry[0], entry[1], this._config).matchesUrl(url))
+        ) || [undefined, undefined];
+
+        const {query, params} = matchedParams;
+        return {name, params, query, route};
+    }
+
+    _currentUrl() {
+        const loc = this._location();
+
+        return (this._config.absolute ? loc.host + loc.pathname :
+            loc.pathname.replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '').replace(/^\/+/, '/')
+        ) + loc.search;
+
+    }
+
+    /**
      * Get the name of the route matching the current window URL, or, given a route name
      * and parameters, check if the current window URL and parameters match that route.
      *
@@ -64,36 +99,36 @@ export default class Router extends String {
      * route().current('posts.show', { post: 1 }); // false
      * route().current('posts.show', { post: 4 }); // true
      *
-     * @param {String} name - Route name to check.
-     * @param {(String|Number|Array|Object)} params - Route parameters.
+     * @param {String} [name] - Route name to check.
+     * @param {(String|Number|Array|Object)} [params] - Route parameters.
      * @return {(Boolean|String|undefined)}
      */
     current(name, params) {
-        const url = this._config.absolute
-            ? this._location().host + this._location().pathname
-            : this._location().pathname.replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '').replace(/^\/+/, '/');
+        const {name: current, params: currentParams, query, route} = this.unresolve();
 
-        // Find the first route that matches the current URL
-        const [current, route] = Object.entries(this._config.routes).find(
-            ([_, route]) => new Route(name, route, this._config).matchesUrl(url)
-        ) || [undefined, undefined];
+        const matchedParams = {...currentParams, ...query};
 
-        // If a name wasn't passed, return the name of the current route
-        if (!name) return current;
+        if (!name) {
+          return current;
+        }
 
         // Test the passed name against the current route, matching some
         // basic wildcards, e.g. passing `events.*` matches `events.show`
         const match = new RegExp(`^${name.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`).test(current);
 
-        if ([null, undefined].includes(params) || !match) return match;
+        if ([null, undefined].includes(params) || !match) {
+          return match;
+        }
 
         const routeObject = new Route(current, route, this._config);
+        const routeParams = JSON.parse(JSON.stringify(matchedParams)); // Remove undefined params
 
         params = this._parse(params, routeObject);
-        const routeParams = this._dehydrate(route);
 
         // If the current window URL has no route parameters, and the passed parameters are empty, return true
-        if (Object.values(params).every(p => !p) && !Object.values(routeParams).length) return true;
+        if (Object.values(params).every(p => !p) && !Object.values(routeParams).length) {
+          return true;
+        }
 
         // Check that all passed parameters match their values in the current window URL
         // Use weak equality because all values in the current window URL will be strings
@@ -126,7 +161,8 @@ export default class Router extends String {
      * @return {Object}
      */
     get params() {
-        return this._dehydrate(this._config.routes[this.current()]);
+        const {params, query} = this.unresolve();
+        return {...params, ...query};
     }
 
     /**
@@ -163,7 +199,7 @@ export default class Router extends String {
         if (Array.isArray(params)) {
             // If the parameters are an array they have to be in order, so we can transform them into
             // an object by keying them with the template segment names in the order they appear
-            params = params.reduce((result, current, i) => !!segments[i] ? ({ ...result, [segments[i].name]: current }) : ({ ...result, [current]: '' }), {});
+            params = params.reduce((result, current, i) => segments[i] ? ({ ...result, [segments[i].name]: current }) : typeof current === 'object' ? ({ ...result, ...current }) : ({ ...result, [current]: '' }), {});
         } else if (
             segments.length === 1
             && !params[segments[0].name]
@@ -226,49 +262,6 @@ export default class Router extends String {
 
             return { ...result, [key]: value[bindings[key]] };
         }, {});
-    }
-
-    /**
-     * Get all parameters and their values from the current window URL, based on the given route definition.
-     *
-     * @example
-     * // at URL https://tighten.ziggy.dev/events/8/venues/chicago?zoom=true
-     * _dehydrate({ domain: '{team}.ziggy.dev', uri: 'events/{event}/venues/{venue?}' }); // { team: 'tighten', event: 8, venue: 'chicago', zoom: true }
-     *
-     * @param {Object} route - Route definition.
-     * @return {Object} Parameters.
-     */
-    _dehydrate(route) {
-        let pathname = this._location().pathname
-            // If this Laravel app is in a subdirectory, trim the subdirectory from the path
-            .replace(this._config.url.replace(/^\w*:\/\/[^/]+/, ''), '')
-            .replace(/^\/+/, '');
-
-        // Given part of a valid 'hydrated' URL containing all its parameter values,
-        // a route template, and a delimiter, extract the parameters as an object
-        // E.g. dehydrate('events/2/chicago', 'events/{event}/{venue}', '/'); // { event: 2, venue: 'chicago' }
-        const dehydrate = (hydrated, template = '', delimiter) => {
-            const [values, segments] = [hydrated, template].map(s => s.split(delimiter));
-
-            return segments.reduce((result, current, i) => {
-                // Only include template segments that are route parameters
-                // AND have a value present in the passed hydrated string
-                return /{[^}?]+\??}/.test(current) && values[i]
-                    ? {
-                        ...result,
-                        [current.replace(/.*{|\??}.*/g, '')]: values[i]
-                            .replace(current.match(/^[^{]*/g), '')
-                            .replace(current.match(/[^}]*$/g), ''),
-                    }
-                    : result;
-            }, {});
-        }
-
-        return {
-            ...dehydrate(this._location().host, route.domain, '.'), // Domain parameters
-            ...dehydrate(pathname, route.uri, '/'), // Path parameters
-            ...parse(this._location().search?.replace(/^\?/, '')), // Query parameters
-        };
     }
 
     valueOf() {

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -37,10 +37,6 @@ export default class Router extends String {
      * @return {String}
      */
     toString() {
-        if (!this._params) {
-            return window.location.toString();
-        }
-
         // Get parameters that don't correspond to any route segments to append them to the query
         const unhandled = Object.keys(this._params)
             .filter((key) => !this._route.parameterSegments.some(({ name }) => name === key))
@@ -108,17 +104,14 @@ export default class Router extends String {
 
         const matchedParams = {...currentParams, ...query};
 
-        if (!name) {
-          return current;
-        }
+        // If a name wasn't passed, return the name of the current route
+        if (!name) return current;
 
         // Test the passed name against the current route, matching some
         // basic wildcards, e.g. passing `events.*` matches `events.show`
         const match = new RegExp(`^${name.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`).test(current);
 
-        if ([null, undefined].includes(params) || !match) {
-          return match;
-        }
+        if ([null, undefined].includes(params) || !match) return match;
 
         const routeObject = new Route(current, route, this._config);
         const routeParams = JSON.parse(JSON.stringify(matchedParams)); // Remove undefined params
@@ -126,9 +119,7 @@ export default class Router extends String {
         params = this._parse(params, routeObject);
 
         // If the current window URL has no route parameters, and the passed parameters are empty, return true
-        if (Object.values(params).every(p => !p) && !Object.values(routeParams).length) {
-          return true;
-        }
+        if (Object.values(params).every(p => !p) && !Object.values(routeParams).length) return true;
 
         // Check that all passed parameters match their values in the current window URL
         // Use weak equality because all values in the current window URL will be strings

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -7,7 +7,9 @@ import route from '../../src/js';
 
 const defaultWindow = {
     location: {
+        protocol: 'https:',
         host: 'ziggy.dev',
+        hash: '',
     },
 };
 
@@ -134,6 +136,59 @@ const defaultZiggy = {
             uri: 'strict-download/file{extension}',
             methods: ['GET', 'HEAD'],
         },
+        'pages.optionalWhere': {
+            uri: 'where/optionalpage/{page?}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                page: '[0-9]+',
+            },
+        },
+        'pages.optionalExtensionWhere': {
+            uri: 'where/download/file{extension?}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                extension: '\\.(php|html)',
+            },
+        },
+        'pages.requiredExtensionWhere': {
+            uri: 'where/strict-download/file{extension}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                extension: '\\.(php|html)',
+            },
+        },
+        'pages.complexWhere': {
+            uri: 'where/{word}-{digit}/{required}/{optional?}/file{extension?}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                word: '[a-z_-]+',
+                digit: '[0-9]+',
+                required: 'required',
+                optional: 'optional',
+                extension: '\\.(php|html)',
+            },
+        },
+        'pages.complexWhereConflict1': {
+            uri: 'where/{digit}-{word}/{required}/{optional?}/file{extension?}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                word: '[a-z_-]+',
+                digit: '[0-9]+',
+                required: 'required',
+                optional: 'optional',
+                extension: '\\.(php|html)',
+            },
+        },
+        'pages.complexWhereConflict2': {
+            uri: 'where/complex-{digit}/{required}/{optional?}/file{extension?}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                digit: '[0-9]+',
+                required: 'different_but_required',
+                optional: 'optional',
+                extension: '\\.(php|html)',
+            },
+        },
         pages: {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
@@ -155,11 +210,18 @@ beforeAll(() => {
 
 beforeEach(() => {
     window.location = { ...defaultWindow.location };
-    global.window.location = { ...defaultWindow.location };
+    window.location.toString = () => window.location.protocol + '//' + window.location.host + window.location.pathname + window.location.search + window.location.hash;
+    global.window.location = window.location;
     global.Ziggy = { ...defaultZiggy };
 });
 
 describe('route()', () => {
+    test('current route URL', () => {
+        global.window.location.pathname = '/subfolder/ph/en/products/4';
+        global.window.location.search = '?abc=test';
+        same(route().toString(), 'https://ziggy.dev/subfolder/ph/en/products/4?abc=test');
+    });
+
     test('can generate a URL with no parameters', () => {
         same(route('posts.index'), 'https://ziggy.dev/posts');
     });
@@ -502,8 +564,9 @@ describe('route()', () => {
 
     test("can append 'extra' string/number parameter to query", () => {
         // 'posts.index' has no parameters
-         same(route('posts.index', 'extra'), 'https://ziggy.dev/posts?extra=');
-         same(route('posts.index', 1), 'https://ziggy.dev/posts?1=');
+        same(route('posts.index', 'extra'), 'https://ziggy.dev/posts?extra=');
+        same(route('posts.index', {extra: 2}), 'https://ziggy.dev/posts?extra=2');
+        same(route('posts.index', 1), 'https://ziggy.dev/posts?1=');
     });
 
     test("can append 'extra' string/number elements in array of parameters to query", () => {
@@ -532,6 +595,19 @@ describe('route()', () => {
         same(route('pages.optionalExtension', '.html'), 'https://ziggy.dev/download/file.html');
         same(route('pages.optionalExtension', { extension: '.pdf' }), 'https://ziggy.dev/download/file.pdf');
     });
+
+    test('can generate a URL for a route with optional parameters inside individual segments respecting where requirements', () => {
+        same(route('pages.optionalExtensionWhere'), 'https://ziggy.dev/where/download/file');
+        same(route('pages.optionalExtensionWhere', '.html'), 'https://ziggy.dev/where/download/file.html');
+        throws(() => route('pages.optionalExtensionWhere', { extension: '.pdf' }), /'extension' parameter does not match required format/);
+    });
+
+    test('can generate a URL for a route with parameters inside individual segments', () => {
+        same(route('pages.requiredExtensionWhere', '.html'), 'https://ziggy.dev/where/strict-download/file.html');
+        throws(() => route('pages.requiredExtensionWhere', 'x'), /'extension' parameter does not match required format/);
+        throws(() => route('pages.requiredExtensionWhere', { extension: '.pdf' }), /'extension' parameter does not match required format/);
+    });
+
 
     test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
         same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four');
@@ -667,6 +743,48 @@ describe('current()', () => {
         same(route().current('pages.optional', { page: '' }), true);
         same(route().current('pages.optional', { page: undefined }), true);
         same(route().current('pages.optional', { page: 'foo' }), false);
+
+        global.window.location.pathname = '/where/optionalpage';
+        same(route().current('pages.optionalWhere', { page: undefined }), true);
+        same(route().current('pages.optionalWhere', { page: 'foo' }), false);
+        global.window.location.pathname = '/where/optionalpage/23';
+        same(route().current('pages.optionalWhere', { page: 23 }), true);
+        same(route().current('pages.optionalWhere', { page: 22 }), false);
+    });
+
+    test('can check current route with complex requirements without conflicts', () => {
+        global.window.location.pathname = '/where/word-12/required/file';
+        same(route().current('pages.complexWhere'), true);
+        same(route().current('pages.complexWhereConflict1'), false);
+
+        global.window.location.pathname = '/where/complex-12/required/file';
+        same(route().current('pages.complexWhere', {word: 'complex', digit: '12', required: 'required'}), true);
+        same(route().current('pages.complexWhereConflict1'), false);
+
+        global.window.location.pathname = '/where/123-abc/required/file.html';
+        same(route().current('pages.complexWhereConflict1'), true);
+        same(route().current('pages.complexWhere'), false);
+
+        global.window.location.pathname = '/where/complex-12/different_but_required/optional/file';
+        same(route().current('pages.complexWhereConflict2'), true);
+        same(route().current('pages.complexWhere'), false);
+    });
+
+    test('can current route with complex requirements is dehydrated correctly', () => {
+        global.window.location.pathname = '/where/word-12/required/file';
+        deepEqual(route().params, {digit: '12', word: 'word', required: 'required', optional: undefined, extension: undefined})
+
+        global.window.location.pathname = '/where/complex-12/required/optional/file';
+        deepEqual(route().params, {digit: '12', word: 'complex', required: 'required', optional: 'optional', extension: undefined})
+
+        global.window.location.pathname = '/where/123-abc/required/file.html';
+        deepEqual(route().params, {digit: '123', word: 'abc', required: 'required', optional: undefined, extension: '.html'})
+
+        global.window.location.pathname = '/where/complex-12/different_but_required/optional/file';
+        deepEqual(route().params, {digit: '12', required: 'different_but_required', optional: 'optional', extension: undefined})
+
+        global.window.location.search = '?ab=cd&ef=1&dd';
+        deepEqual(route().params, {digit: '12', required: 'different_but_required', optional: 'optional', extension: undefined, ab: 'cd', ef: '1', 'dd': ''})
     });
 
     test('can check the current route name at a URL with a non-delimited parameter', () => {
@@ -721,6 +839,12 @@ describe('current()', () => {
         same(route().current('pages.optionalExtension*', { extension: '.pdf' }), false);
         same(route().current('pages.optionalExtension', { extension: '.html' }), true);
         same(route().current('pages.optionalExtension*', { extension: '.html' }), true);
+
+        global.window.location.pathname = '/where/download/file.html';
+        same(route().current('pages.optionalExtensionWhere', { extension: '.html' }), true);
+
+        global.window.location.pathname = '/where/download/file.pdf';
+        same(route().current('pages.optionalExtensionWhere', { extension: '.pdf' }), false);
     });
 
     test('can check the current route name with parameters on a URL with no parameters', () => {
@@ -919,6 +1043,15 @@ describe('current()', () => {
         same(route().current('events.venues.*'), false);
     });
 
+
+    test('can unresolve arbitrary urls to names and params', () => {
+        const resolved = route().unresolve('https://ziggy.dev/events/1/venues?test=yes');
+        deepEqual(resolved, { name: 'events.venues.index', params: {event: '1'}, query: {test: 'yes'}, route: resolved.route });
+        same(resolved.route.uri, 'events/{event}/venues');
+
+        same(route().unresolve('ziggy.dev/events/1/venues-index').name, 'events.venues-index');
+    });
+
     test('can get the current route name without window', () => {
         global.Ziggy = undefined;
         global.window = undefined;
@@ -937,6 +1070,7 @@ describe('current()', () => {
                 },
             },
             location: {
+                protocol: 'https:',
                 host: 'ziggy.dev',
                 pathname: '/events/1/venues/2',
                 search: '?user=Jacob&id=9',

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1043,15 +1043,6 @@ describe('current()', () => {
         same(route().current('events.venues.*'), false);
     });
 
-
-    test('can unresolve arbitrary urls to names and params', () => {
-        const resolved = route().unresolve('https://ziggy.dev/events/1/venues?test=yes');
-        deepEqual(resolved, { name: 'events.venues.index', params: {event: '1'}, query: {test: 'yes'}, route: resolved.route });
-        same(resolved.route.uri, 'events/{event}/venues');
-
-        same(route().unresolve('ziggy.dev/events/1/venues-index').name, 'events.venues-index');
-    });
-
     test('can get the current route name without window', () => {
         global.Ziggy = undefined;
         global.window = undefined;

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -216,12 +216,6 @@ beforeEach(() => {
 });
 
 describe('route()', () => {
-    test('current route URL', () => {
-        global.window.location.pathname = '/subfolder/ph/en/products/4';
-        global.window.location.search = '?abc=test';
-        same(route().toString(), 'https://ziggy.dev/subfolder/ph/en/products/4?abc=test');
-    });
-
     test('can generate a URL with no parameters', () => {
         same(route('posts.index'), 'https://ziggy.dev/posts');
     });
@@ -565,7 +559,7 @@ describe('route()', () => {
     test("can append 'extra' string/number parameter to query", () => {
         // 'posts.index' has no parameters
         same(route('posts.index', 'extra'), 'https://ziggy.dev/posts?extra=');
-        same(route('posts.index', {extra: 2}), 'https://ziggy.dev/posts?extra=2');
+        same(route('posts.index', [{extra: 2}]), 'https://ziggy.dev/posts?extra=2');
         same(route('posts.index', 1), 'https://ziggy.dev/posts?1=');
     });
 
@@ -1041,6 +1035,14 @@ describe('current()', () => {
 
         same(route().current('events.venues-index'), true);
         same(route().current('events.venues.*'), false);
+    });
+
+    test('can unresolve arbitrary urls to names and params', () => {
+        const resolved = route().unresolve('https://ziggy.dev/events/1/venues?test=yes');
+        deepEqual(resolved, { name: 'events.venues.index', params: {event: '1'}, query: {test: 'yes'}, route: resolved.route });
+        same(resolved.route.uri, 'events/{event}/venues');
+
+        same(route().unresolve('ziggy.dev/events/1/venues-index').name, 'events.venues-index');
     });
 
     test('can get the current route name without window', () => {


### PR DESCRIPTION
Updated the route matching logic to take the wheres into account, completed a todo and improved performance,
I removed the _dehydrate part which became useless since all this now happens in the regex matching

Fixes #513 

- [x] Thorough tests 
- [x] ~~Do we need to support a few old browsers ? ([which don't support](https://caniuse.com/mdn-javascript_builtins_regexp_named_capture_groups) named capturing regex groups), if yes then it's possible to implement a workaround to named groups quite easily~~