### PR TITLE
feat: Add Vue3 Provide/Inject Plugin

### DIFF
--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -1,9 +1,11 @@
 import route from './index.js';
 
 export const ZiggyVue = {
-    install: (v, options) => v.mixin({
-        methods: {
-            route: (name, params, absolute, config = options) => route(name, params, absolute, config),
-        },
-    }),
+    install: (v, options) => {
+        const version = parseInt(v.version.split('.')[0]);
+        const _route = (name, params, absolute, config = options) => route(name, params, absolute, config);
+
+        v.mixin && version === 2 && (v.mixin({ methods: { route: _route } }));
+        v.provide && version > 2 && (v.provide('route', _route));
+    },
 };

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -2,10 +2,17 @@ import route from './index.js';
 
 export const ZiggyVue = {
     install: (v, options) => {
-        const version = parseInt(v.version.split('.')[0]);
-        const _route = (name, params, absolute, config = options) => route(name, params, absolute, config);
+        const r = (name, params, absolute, config = options) => route(name, params, absolute, config);
 
-        v.mixin && version === 2 && (v.mixin({ methods: { route: _route } }));
-        v.provide && version > 2 && (v.provide('route', _route));
+        v.mixin({
+            methods: {
+                route: r,
+            },
+        });
+
+        if (parseInt(v.version > 2)) {
+            v.provide('route', r);
+            v.config.globalProperties.$route = r;
+        }
     },
 };

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -10,7 +10,7 @@ export const ZiggyVue = {
             },
         });
 
-        if (parseInt(v.version > 2)) {
+        if (parseInt(v.version) > 2) {
             v.provide('route', r);
         }
     },

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -12,7 +12,6 @@ export const ZiggyVue = {
 
         if (parseInt(v.version > 2)) {
             v.provide('route', r);
-            v.config.globalProperties.$route = r;
         }
     },
 };


### PR DESCRIPTION
This PR adds a new plugin for Vue3 using Ziggy via the Provide/Inject Composition API. Using the [advanced Vue set up](https://github.com/tighten/ziggy#vue), I ran into my problem when trying to use `route()` in `setup()`. I saw a possible solution in https://github.com/tighten/ziggy/issues/454#issuecomment-906418423 but it didn't feel like a super maintainable solution, also `mixins` are [not recommended](https://vuejs.org/api/application.html#app-mixin) in Vue3 anymore.

> Note: I'm not familiar with microbundles, so if anything needs to be edited in package.json, please let me know.

For this to work, you have to update your `mix` alias like below:

```javascript
mix.alias({
    ziggy: path.resolve('vendor/tightenco/ziggy/dist/vue3'), 
});
```

and the import of `ZiggyVue3`:

```javascript
import { createApp } from 'vue';
import { ZiggyVue3 } from 'ziggy';
import { Ziggy } from './ziggy';
import App from './App';

createApp(App).use(ZiggyVue3, Ziggy);
```

The `route()` helper will still be registered globally and you gain the below functionality:

```javascript
<script>
import { inject } from 'vue';

export default {
    setup() {
        const route = inject('route');

        const navigation = [{
            name: 'Profile',
            href: route('profile'),
            current: route().current('profile'),
        }, {
            name: 'Settings',
            href: route('settings'),
            current: route().current('settings'),
        }, {
         ...
        }];

        return {
            navigation,
        };
    },
};
</script>
```