### PR TITLE
feat: Add watcher option to generate command and allow for options to be specified multiple times

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: inotify
       - uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@ You can run PHP tests with `vendor/bin/phpunit` and JavaScript tests with `npm t
 
 If you need any help with this please don't hesitate to ask.
 
+> :warning: If your filesystem uses CRLF instead of LF you may run into some issues when running the tests
+> You can run `find . -type f -not -path "./vendor" -not -path "./node_modules" -exec grep -qIP '\r$' {} ';' -exec perl -pi -e 's/\r\n/\n/g' {} '+'` to restore files back to LF
+
 ## Requirements
 
 - **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer).

--- a/README.md
+++ b/README.md
@@ -312,7 +312,22 @@ You can optionally create a webpack alias and a before script to make generating
 const {exec} = require('child_process');
 
 mix.before(async () => {
-  await exec('php artisan ziggy:generate');
+  return new Promise((resolve, reject) => {
+    const process = exec('php artisan ziggy:generate');
+    process.stdout.on('data', (data) => {
+      console.log(data);
+    });
+    process.stderr.on('data', (data) => {
+      console.error(data);
+    });
+    process.on('exit', code => {
+      if (code !== 0) {
+        reject();
+      } else {
+        resolve();
+      }
+    });
+  });
 });
 
 // Mix v6

--- a/README.md
+++ b/README.md
@@ -305,10 +305,15 @@ const Ziggy = {
 export { Ziggy };
 ```
 
-You can optionally create a webpack alias to make importing Ziggy's core source files easier:
+You can optionally create a webpack alias and a before script to make generating and importing Ziggy's core source files easier:
 
 ```js
 // webpack.mix.js
+const {exec} = require('child_process');
+
+mix.before(async () => {
+  await exec('php artisan ziggy:generate');
+});
 
 // Mix v6
 const path = require('path');
@@ -348,7 +353,12 @@ route('home', undefined, undefined, Ziggy);
 
 During development you may want to watch for changes in your routes and automatically regenerate the file, you just need to run the same command with the `--watch` option
 
-`php artisan ziggy:generate ./resources/js/admin.js ./resources/js/public.js --group=admin --group=public --watch`
+`php artisan ziggy:generate ./resources/js/public.js --group ./resources/js/admin.js --group=admin --watch`
+
+If you're using laravel mix, for instance, you could change your watch script in your package.json to
+```
+"watch": "php artisan ziggy:generate --watch & mix watch",
+```
 
 #### Vue
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,14 @@ import { Ziggy } from './ziggy';
 route('home', undefined, undefined, Ziggy);
 ```
 
+##### Watcher
+
+> :warning: **The following requires ext-inotify to be installed on your php handler**
+
+During development you may want to watch for changes in your routes and automatically regenerate the file, you just need to run the same command with the `--watch` option
+
+`php artisan ziggy:generate ./resources/js/admin.js ./resources/js/public.js --group=admin --group=public --watch`
+
 #### Vue
 
 Ziggy includes a Vue plugin to make it easy to use the `route()` helper throughout your Vue app:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,11 @@
             "email": "jacob@tighten.co"
         }
     ],
+    "suggest": {
+        "ext-inotify": "To use the watch option of the generate command"
+    },
     "require": {
+        "ext-json": "*",
         "laravel/framework": ">=5.4@dev"
     },
     "require-dev": {

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -117,6 +117,7 @@ class CommandRouteGenerator extends Command
                 return inotify_rm_watch($fd, $watcher);
             }, $watchers);
             fclose($fd);
+            $this->info('Thanks for watching! ;)');
             return;
         } else if ($watch !== 'false') {
             $this->error('The watch option requires the PHP extension ext-inotify');

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -3,16 +3,20 @@
 namespace Tightenco\Ziggy;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Tightenco\Ziggy\Output\File;
-use Tightenco\Ziggy\Ziggy;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+use Symfony\Component\Console\Input\StreamableInputInterface;
 
 class CommandRouteGenerator extends Command
 {
     protected $signature = 'ziggy:generate
-                            {path=./resources/js/ziggy.js : Path to the generated JavaScript file.}
-                            {--url=}
-                            {--group=}';
+                            {path=*./resources/js/ziggy.js : Path to the generated JavaScript file.}
+                            {--watch=false}
+                            {--url=*}
+                            {--group=*}';
 
     protected $description = 'Generate a JavaScript file containing Ziggy’s routes and configuration.';
 
@@ -27,13 +31,125 @@ class CommandRouteGenerator extends Command
 
     public function handle()
     {
-        $path = $this->argument('path');
-        $generatedRoutes = $this->generate($this->option('group'));
+        $watch = $this->option('watch');
 
-        $this->makeDirectory($path);
-        $this->files->put(base_path($path), $generatedRoutes);
+        if ($watch !== 'false' && function_exists('inotify_init')) {
+            $this->process();
 
-        $this->info('File generated!');
+            $stream = ($this->input instanceof StreamableInputInterface ? $this->input->getStream() : null) ?? \STDIN;
+            if (!$stream) {
+                $this->error('Not an interactive stream, avoiding infinite execution');
+            }
+
+            $fd = inotify_init();
+
+            // Prepare list of files to watch
+            $files = [
+                config_path('ziggy.php'),
+                base_path('routes')
+            ];
+            if (!empty($watch) && is_string($watch)) {
+                $files = array_merge($files, array_map(function ($file) {
+                    return base_path(trim($file));
+                }, explode(',', $watch)));
+            }
+            $files = array_filter($files, 'file_exists');
+
+            $this->info('Watching '.join(', ', $files));
+
+            // We don't want to block the execution while waiting for Enter
+            stream_set_blocking($stream, 0);
+            $this->question('Press enter to exit');
+
+
+            // We also don't want to block the execution while waiting for a file change
+            stream_set_blocking($fd, 0);
+
+            // Start watching
+            $watchers = array_map(function ($file) use ($fd) {
+                return inotify_add_watch($fd, $file, IN_MODIFY);
+            }, $files);
+
+            // We need to reboot the app
+            // but it's only possible by modifying a protected property in laravel
+            // so use some reflection magic
+            $app = app();
+            $booted = new \ReflectionProperty($app, 'booted');
+            $providers = new \ReflectionProperty($app, 'serviceProviders');
+            $backup = $providers->getValue($app);
+            $routeOnly = array_filter($backup, function ($p) {
+                return $p instanceof RouteServiceProvider;
+            });
+
+            do {
+                if (inotify_read($fd)) {
+                    // Reload config
+                    (new LoadConfiguration())->bootstrap($app);
+
+                    // Reload routes with reflection magic
+                    $booted->setValue($app, false);
+                    $providers->setValue($app, $routeOnly);
+                    $app->boot();
+                    $providers->setValue($app, $backup);
+
+                    // Clear ziggy cache and generate
+                    Ziggy::clearRoutes();
+
+                    if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
+                        \Fiber::suspend('before-generate');
+                    }
+
+                    $this->process();
+
+                    if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
+                        \Fiber::suspend('generated');
+                    }
+                }
+                if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
+                    $continue = \Fiber::suspend('waiting');
+                } else {
+                    sleep(1);
+                    $continue = ("" === fread($stream, 1));
+                }
+            } while ($continue);
+
+            array_map(function ($watcher) use ($fd) {
+                return inotify_rm_watch($fd, $watcher);
+            }, $watchers);
+            fclose($fd);
+            return;
+        } else if ($watch !== 'false') {
+            $this->error('The watch option requires the PHP extension ext-inotify');
+        }
+        $this->process();
+    }
+
+    private function get($value, $index) {
+        if (is_array($value)) {
+            return $value[$index] ?? null;
+        }
+        return $value;
+    }
+
+    private function process() {
+        $paths = $this->argument('path');
+        foreach ((array)$paths as $index => $path) {
+            $generatedRoutes = $this->generate(
+                $this->get($this->option('group'), $index) ?? '',
+                $this->get($this->option('url'), $index) ? url($this->get($this->option('url'), $index)) : null
+            );
+
+            $this->makeDirectory($path);
+            try {
+                $prevContent = $this->files->get(base_path($path));
+            } catch (FileNotFoundException $e) {
+                $prevContent = '';
+            }
+            if ($prevContent != $generatedRoutes) {
+                $this->files->put(base_path($path), $generatedRoutes);
+                $this->info('File '.$path.' generated!');
+            }
+        }
     }
 
     protected function makeDirectory($path)
@@ -45,9 +161,9 @@ class CommandRouteGenerator extends Command
         return $path;
     }
 
-    private function generate($group = false)
+    private function generate($group = false, $url = null)
     {
-        $ziggy = (new Ziggy($group, $this->option('url') ? url($this->option('url')) : null));
+        $ziggy = new Ziggy($group, $url);
 
         $output = config('ziggy.output.file', File::class);
 

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -83,26 +83,30 @@ class CommandRouteGenerator extends Command
 
             do {
                 if (inotify_read($fd)) {
-                    // Reload config
-                    (new LoadConfiguration())->bootstrap($app);
+                    try {
+                        // Reload config
+                        (new LoadConfiguration())->bootstrap($app);
 
-                    // Reload routes with reflection magic
-                    $booted->setValue($app, false);
-                    $providers->setValue($app, $routeOnly);
-                    $app->boot();
-                    $providers->setValue($app, $backup);
+                        // Reload routes with reflection magic
+                        $booted->setValue($app, false);
+                        $providers->setValue($app, $routeOnly);
+                        $app->boot();
+                        $providers->setValue($app, $backup);
 
-                    // Clear ziggy cache and generate
-                    Ziggy::clearRoutes();
+                        // Clear ziggy cache and generate
+                        Ziggy::clearRoutes();
 
-                    if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
-                        \Fiber::suspend('before-generate');
-                    }
+                        if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
+                            \Fiber::suspend('before-generate');
+                        }
 
-                    $this->process();
-
-                    if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
-                        \Fiber::suspend('generated');
+                        $this->process();
+                        if ($app->runningUnitTests() && class_exists(\Fiber::class)) {
+                            \Fiber::suspend('generated');
+                        }
+                    } catch (\Throwable $e) {
+                        $this->error($e->getMessage());
+                        // Don't exit the loop but display the error
                     }
                 }
                 if ($app->runningUnitTests() && class_exists(\Fiber::class)) {

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -56,7 +56,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
             ],
-        ], json_decode(Str::after(Str::before($script, ";\n\n"), 'routes = '), true));
+        ], $payload);
     }
 
     /** @test */

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Tests\TestCase;
 use Tightenco\Ziggy\Output\File;
@@ -145,7 +144,7 @@ class CommandRouteGeneratorTest extends TestCase
         $router->get('admin', $this->noop())->name('admin.dashboard');
         $router->getRoutes()->refreshNameLookups();
 
-        Artisan::call('ziggy:generate', ['path' => ['resources/js/admin.js', 'resources/js/public.js'], '--group' => ['admin']]);
+        Artisan::call('ziggy:generate', ['path' => ['resources/js/admin.js', 'resources/js/public.js'], '--group' => ['admin'], '--url' => [null, 'http://example.org']]);
 
         $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
         $this->assertFileEquals('./tests/fixtures/public.js', base_path('resources/js/public.js'));
@@ -175,7 +174,7 @@ class CommandRouteGeneratorTest extends TestCase
         file_put_contents(base_path('config/watched.php'), '<?php //1');
 
         $fiber = new \Fiber(function() : void {
-            Artisan::call('ziggy:generate', ['path' => ['resources/js/admin.js', 'resources/js/public.js'], '--group' => ['admin'], '--watch' => 'config/watched.php']);
+            Artisan::call('ziggy:generate', ['path' => ['resources/js/admin.js', 'resources/js/public.js'], '--group' => ['admin'], '--url' => [null, 'http://example.org'], '--watch' => 'config/watched.php']);
         });
         $fiber->start();
 

--- a/tests/fixtures/admin-watch.js
+++ b/tests/fixtures/admin-watch.js
@@ -1,0 +1,7 @@
+const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]},"admin.second":{"uri":"admin\/second","methods":["GET","HEAD"]}}};
+
+if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
+}
+
+export { Ziggy };

--- a/tests/fixtures/public.js
+++ b/tests/fixtures/public.js
@@ -1,0 +1,7 @@
+const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+
+if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
+    Object.assign(Ziggy.routes, window.Ziggy.routes);
+}
+
+export { Ziggy };

--- a/tests/fixtures/public.js
+++ b/tests/fixtures/public.js
@@ -1,4 +1,4 @@
-const Ziggy = {"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
+const Ziggy = {"url":"http:\/\/example.org","port":null,"defaults":{},"routes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     Object.assign(Ziggy.routes, window.Ziggy.routes);


### PR DESCRIPTION
This is a very nice backward compatible improvement to the ziggy:generate command

It allows the command to wait until Enter is pressed meanwhile watching for file change to regenerate them, this is very usefull in conjonction with the watch option of webpack or laravel mix as it allows for a development process not requiring manually running commands

Here is an example of usage
`php artisan ziggy:generate ./resources/js/Routes/admin.js  --group=admin ./resources/js/Routes/public.js --watch`