### PR TITLE
feat: add webpack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,16 @@ const Ziggy = {
 export { Ziggy };
 ```
 
-You can optionally create a webpack alias to make importing Ziggy's core source files easier:
+You can optionally create a webpack alias and our webpack plugin to make generating and importing Ziggy's core source files easier:
 
 ```js
 // webpack.mix.js
+const {exec} = require('child_process');
+
+const ZiggyWebpackPlugin = require('./vendor/tightenco/ziggy/webpackPlugin');
+mix.webpackConfig({
+  plugins: [new ZiggyWebpackPlugin('php artisan ziggy:generate')],
+});
 
 // Mix v6
 const path = require('path');

--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ const Ziggy = {
 export { Ziggy };
 ```
 
-You can optionally create a webpack alias and our webpack plugin to make generating and importing Ziggy's core source files easier:
+You can optionally create a webpack alias and use our webpack plugin to make generating and importing Ziggy's core source files easier:
 
 ```js
 // webpack.mix.js
 const {exec} = require('child_process');
 
+// Webpack plugin
 const ZiggyWebpackPlugin = require('./vendor/tightenco/ziggy/webpackPlugin');
 mix.webpackConfig({
   plugins: [new ZiggyWebpackPlugin('php artisan ziggy:generate')],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,13 @@
             },
             "devDependencies": {
                 "babel-preset-power-assert": "^3.0.0",
-                "jest": "^27.0.6",
+                "jest": "^27.5.1",
                 "microbundle": "^0.14.2",
-                "power-assert": "^1.6.1"
+                "power-assert": "^1.6.1",
+                "webpack": "^5.70.0"
+            },
+            "optionalDependencies": {
+                "webpack": "^5"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2383,6 +2387,26 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+            "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "0.0.39",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2421,6 +2445,12 @@
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "dev": true
         },
         "node_modules/@types/node": {
             "version": "17.0.21",
@@ -2470,6 +2500,164 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
+        },
         "node_modules/abab": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2516,6 +2704,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
         "node_modules/acorn-walk": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -2535,6 +2732,31 @@
             },
             "engines": {
                 "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
+            "peerDependencies": {
+                "ajv": "^6.9.1"
             }
         },
         "node_modules/ansi-escapes": {
@@ -3056,6 +3278,15 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/ci-info": {
@@ -3698,6 +3929,19 @@
                 "core-js": "^2.0.0"
             }
         },
+        "node_modules/enhanced-resolve": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+            "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -3749,6 +3993,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
         },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
@@ -3829,6 +4079,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/espower-location-detector": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
@@ -3863,6 +4126,27 @@
                 "core-js": "^2.0.0"
             }
         },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
@@ -3892,6 +4176,15 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.x"
+            }
         },
         "node_modules/execa": {
             "version": "5.1.1",
@@ -3939,6 +4232,12 @@
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -4207,6 +4506,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -5661,10 +5966,22 @@
                 "node": ">=4"
             }
         },
+        "node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "node_modules/json5": {
@@ -5736,6 +6053,15 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
+        },
+        "node_modules/loader-runner": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.11.5"
+            }
         },
         "node_modules/loader-utils": {
             "version": "3.2.0",
@@ -6110,6 +6436,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
         "node_modules/node-int64": {
@@ -7693,6 +8025,24 @@
                 "node": ">=10"
             }
         },
+        "node_modules/schema-utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8060,6 +8410,15 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -8092,6 +8451,58 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/terser-webpack-plugin": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+            "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+            "dev": true,
+            "dependencies": {
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "source-map": "^0.6.1",
+                "terser": "^5.7.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "dev": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/terser/node_modules/commander": {
@@ -8346,6 +8757,15 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8405,6 +8825,19 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/watchpack": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+            "dev": true,
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -8413,6 +8846,68 @@
             "engines": {
                 "node": ">=10.4"
             }
+        },
+        "node_modules/webpack": {
+            "version": "5.70.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+            "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.4.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.9.2",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.9",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.3.1",
+                "webpack-sources": "^3.2.3"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack/node_modules/@types/estree": {
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+            "dev": true
         },
         "node_modules/whatwg-encoding": {
             "version": "1.0.5",
@@ -10315,6 +10810,26 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/eslint": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/eslint-scope": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+            "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+            "dev": true,
+            "requires": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "@types/estree": {
             "version": "0.0.39",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -10353,6 +10868,12 @@
             "requires": {
                 "@types/istanbul-lib-report": "*"
             }
+        },
+        "@types/json-schema": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "dev": true
         },
         "@types/node": {
             "version": "17.0.21",
@@ -10402,6 +10923,164 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
+        "@webassemblyjs/ast": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
+        },
         "abab": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -10438,6 +11117,13 @@
                 }
             }
         },
+        "acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "requires": {}
+        },
         "acorn-walk": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -10452,6 +11138,25 @@
             "requires": {
                 "debug": "4"
             }
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
+            "requires": {}
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -10855,6 +11560,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
+        },
+        "chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "dev": true
         },
         "ci-info": {
@@ -11357,6 +12068,16 @@
                 "core-js": "^2.0.0"
             }
         },
+        "enhanced-resolve": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+            "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            }
+        },
         "entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -11399,6 +12120,12 @@
                 "string.prototype.trimstart": "^1.0.4",
                 "unbox-primitive": "^1.0.1"
             }
+        },
+        "es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
         },
         "es-to-primitive": {
             "version": "1.2.1",
@@ -11451,6 +12178,16 @@
                 }
             }
         },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            }
+        },
         "espower-location-detector": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
@@ -11478,6 +12215,23 @@
                 "core-js": "^2.0.0"
             }
         },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true
+                }
+            }
+        },
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
@@ -11500,6 +12254,12 @@
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true
         },
         "execa": {
@@ -11536,6 +12296,12 @@
                 "jest-matcher-utils": "^27.5.1",
                 "jest-message-util": "^27.5.1"
             }
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -11735,6 +12501,12 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
+        },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true
         },
         "globals": {
             "version": "11.12.0",
@@ -12835,10 +13607,22 @@
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json5": {
@@ -12891,6 +13675,12 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
+        },
+        "loader-runner": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
             "dev": true
         },
         "loader-utils": {
@@ -13195,6 +13985,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
         "node-int64": {
@@ -14342,6 +15138,17 @@
                 "xmlchars": "^2.2.0"
             }
         },
+        "schema-utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            }
+        },
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -14629,6 +15436,12 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true
+        },
         "terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -14661,6 +15474,36 @@
                     "version": "0.7.3",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+            "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+            "dev": true,
+            "requires": {
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "source-map": "^0.6.1",
+                "terser": "^5.7.2"
+            },
+            "dependencies": {
+                "serialize-javascript": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+                    "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+                    "dev": true,
+                    "requires": {
+                        "randombytes": "^2.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
@@ -14850,6 +15693,15 @@
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
         },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14902,10 +15754,66 @@
                 "makeerror": "1.0.12"
             }
         },
+        "watchpack": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+            "dev": true,
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            }
+        },
         "webidl-conversions": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
             "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+            "dev": true
+        },
+        "webpack": {
+            "version": "5.70.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+            "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+            "dev": true,
+            "requires": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.4.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.9.2",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.9",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.3.1",
+                "webpack-sources": "^3.2.3"
+            },
+            "dependencies": {
+                "@types/estree": {
+                    "version": "0.0.51",
+                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+                    "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true
         },
         "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     ],
     "files": [
         "src/js",
-        "dist"
+        "dist",
+        "webpackPlugin.js"
     ],
     "source": "src/js/index.js",
     "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,14 @@
     "dependencies": {
         "qs": "~6.9.7"
     },
+    "optionalDependencies": {
+        "webpack": "^5"
+    },
     "devDependencies": {
         "babel-preset-power-assert": "^3.0.0",
-        "jest": "^27.0.6",
+        "jest": "^27.5.1",
         "microbundle": "^0.14.2",
-        "power-assert": "^1.6.1"
+        "power-assert": "^1.6.1",
+        "webpack": "^5.70.0"
     }
 }

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -3,9 +3,9 @@
 namespace Tightenco\Ziggy;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Tightenco\Ziggy\Output\File;
-use Tightenco\Ziggy\Ziggy;
 
 class CommandRouteGenerator extends Command
 {
@@ -31,9 +31,15 @@ class CommandRouteGenerator extends Command
         $generatedRoutes = $this->generate($this->option('group'));
 
         $this->makeDirectory($path);
-        $this->files->put(base_path($path), $generatedRoutes);
-
-        $this->info('File generated!');
+        try {
+            $prevContent = $this->files->get(base_path($path));
+        } catch (FileNotFoundException) {
+            $prevContent = '';
+        }
+        if ($prevContent != $generatedRoutes) {
+            $this->files->put(base_path($path), $generatedRoutes);
+            $this->info('File '.$path.' generated!');
+        }
     }
 
     protected function makeDirectory($path)

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -33,7 +33,7 @@ class CommandRouteGenerator extends Command
         $this->makeDirectory($path);
         try {
             $prevContent = $this->files->get(base_path($path));
-        } catch (FileNotFoundException) {
+        } catch (FileNotFoundException $e) {
             $prevContent = '';
         }
         if ($prevContent != $generatedRoutes) {

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\URL;
 use Tests\TestCase;
 use Tightenco\Ziggy\Output\File;
+use Tightenco\Ziggy\Ziggy;
 
 class CommandRouteGeneratorTest extends TestCase
 {
@@ -130,6 +131,26 @@ class CommandRouteGeneratorTest extends TestCase
         Artisan::call('ziggy:generate', ['path' => 'resources/js/admin.js', '--group' => 'admin']);
 
         $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
+    }
+
+    /** @test */
+    public function doesnt_touch_file_if_not_modified() {
+        Artisan::call('ziggy:generate');
+        $time = filemtime(base_path('resources/js/ziggy.js'));
+        sleep(1);
+
+        Ziggy::clearRoutes();
+        Artisan::call('ziggy:generate');
+        $this->assertEquals($time, filemtime(base_path('resources/js/ziggy.js')));
+
+        $router = app('router');
+        $router->get('posts/{post}/comments', $this->noop())->name('postComments.index');
+        $router->get('slashes/{slug}', $this->noop())->where('slug', '.*')->name('slashes');
+        $router->getRoutes()->refreshNameLookups();
+
+        Ziggy::clearRoutes();
+        Artisan::call('ziggy:generate');
+        $this->assertNotEquals($time, filemtime(base_path('resources/js/ziggy.js')));
     }
 }
 

--- a/tests/fixtures/entry.js
+++ b/tests/fixtures/entry.js
@@ -1,0 +1,5 @@
+// Entry file for the tests of the webpack plugin
+import route from '../../src/js';
+import routes from './ziggy';
+
+route('postComments.index', 1, true, routes);

--- a/tests/js/webpackPlugin.test.js
+++ b/tests/js/webpackPlugin.test.js
@@ -1,0 +1,142 @@
+import webpack from 'webpack';
+
+import ZiggyWebpackPlugin from '../../webpackPlugin';
+
+const fs = require('fs');
+const path = require('path');
+
+let compiler;
+const make = (command, options) => {
+    compiler = webpack({
+        mode: 'none',
+        output: {
+            path: path.resolve(__dirname, '../dist'),
+        },
+        watchOptions: {
+            aggregateTimeout: 0,
+        },
+        entry: path.resolve(__dirname, '../fixtures/entry.js'),
+        plugins: [new ZiggyWebpackPlugin(command, { path: 'vendor/orchestra/testbench-core/laravel', ...options })],
+    });
+    return compiler;
+};
+
+const consoleError = console.error;
+const consoleLog = console.log;
+const mockConsole = () => {
+    console.log = jest.fn();
+    console.error = jest.fn();
+};
+
+const restoreConsole = () => {
+    console.log = consoleLog;
+    console.error = consoleError;
+};
+
+const mockAsync = () => jest.fn(() => new Promise(resolve => setTimeout(resolve, 10)));
+
+beforeEach(() => {
+    mockConsole();
+});
+
+afterEach((done) => {
+    if (compiler) {
+        compiler.close((closeErr) => {
+            console.log('closed')
+            done(closeErr);
+        });
+    } else {
+        done();
+    }
+
+    restoreConsole();
+});
+
+afterAll(() => {
+    // Cleanup files
+    try {
+        fs.rmdirSync(path.resolve(__dirname, '../dist'), { recursive: true });
+    } catch (e) {
+        console.error(e);
+    }
+    try {
+        fs.rmSync(path.resolve(__dirname, '../fixtures/watch.txt'));
+    } catch (e) {
+        console.error(e);
+    }
+})
+
+describe('webpack plugin', () => {
+    test('compiles before run', () => new Promise((resolve, reject) => {
+        const fn = mockAsync();
+        make((...a) => fn.apply(null, a)) // fn instanceof Function is false, so wrap it
+            .run((err, stats) => {
+                if (err) {
+                    return reject(err);
+                } else if (stats.hasErrors()) {
+                    return reject(stats.toString());
+                }
+                expect(fn).toHaveBeenCalledTimes(1);
+                resolve();
+            });
+    }));
+
+    test('run command redirects output', () => new Promise((resolve, reject) => {
+        make('echo "ok" && >&2 echo "error"')
+            .run((err, stats) => {
+                if (err) {
+                    return reject(err);
+                } else if (stats.hasErrors()) {
+                    return reject(stats.toString());
+                }
+                expect(console.log).toHaveBeenCalledWith('ok\n');
+                expect(console.error).toHaveBeenCalledWith('error\n');
+                resolve();
+            });
+    }));
+
+    test('watches for change', () => {
+        restoreConsole();
+        const prev = fs.readFileSync(path.resolve(__dirname, '../fixtures/ziggy.js'));
+        return new Promise((resolve, reject) => {
+            const watch = path.resolve(__dirname, '../fixtures/watch.txt');
+            fs.writeFileSync(watch, 'test1');
+            const filesCb = jest.fn((files) => {
+                expect(files).toContain(path.resolve(__dirname, '../../vendor/orchestra/testbench-core/laravel/config/ziggy.php'));
+                files.push(watch);
+                return files;
+            });
+            let run = 1;
+            const fn = mockAsync();
+            make((...a) => fn.apply(null, a), { filesToWatchCallback: (...a) => filesCb.apply(null, a) });
+            const emitted = jest.fn();
+            compiler.hooks.emit.tap('Test', emitted);
+            compiler = compiler.watch({}, (err, stats) => {
+                if (err) {
+                    return reject(err);
+                } else if (stats.hasErrors()) {
+                    return reject(stats.toString());
+                }
+
+                switch (run) {
+                    case 1:
+                        expect(emitted).toHaveBeenCalledTimes(1); // It should have been called once on initial compilation
+                        expect(fn).toHaveBeenCalledTimes(1);
+                        fs.promises.writeFile(watch, 'test2').catch(reject);
+                        setTimeout(() => {
+                            expect(fn).toHaveBeenCalledTimes(2);
+                            // It shouldn't have triggered a rebuild because watched file is not actually required by our entry.js
+                            expect(emitted).toHaveBeenCalledTimes(1);
+                            fs.promises.appendFile(path.resolve(__dirname, '../fixtures/ziggy.js'), 'console.log("test");').catch(reject);
+                        }, 100);
+                        break;
+                    default:
+                        expect(emitted).toHaveBeenCalledTimes(run);
+                        resolve();
+                        break;
+                }
+                run++;
+            });
+        }).then(() => fs.writeFileSync(path.resolve(__dirname, '../fixtures/ziggy.js'), prev));
+    });
+});

--- a/webpackPlugin.js
+++ b/webpackPlugin.js
@@ -1,0 +1,100 @@
+const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Those are both webpack dependencies
+const validate = require('schema-utils').validate || require('schema-utils'); // In a previous version it was exported as default
+const Watchpack = require('watchpack');
+
+module.exports = class ZiggyWebpackPlugin {
+    /**
+     *
+     * @param {string|function} command
+     * @param {{path: string, filesToWatchCallback: function}} [options]
+     */
+    constructor(command, options = {}) {
+        validate({
+            anyOf: [
+                { type: 'string' },
+                { instanceof: 'Function' },
+            ],
+            description: 'The command or async callback to run the compilation',
+        }, command, {
+            name: 'Ziggy Webpack Plugin',
+            baseDataPath: 'command',
+        });
+        validate({
+            type: 'object',
+            properties: {
+                path: {
+                    description: 'This is the base path, where laravel is installed',
+                    type: 'string',
+                },
+                filesToWatchCallback: {
+                    description: 'If you need to change the list of watched files',
+                    instanceof: 'Function',
+                },
+            },
+            additionalProperties: false,
+        }, options, {
+            name: 'Ziggy Webpack Plugin',
+            baseDataPath: 'options',
+        });
+        this.command = command;
+        this.path = options.path || './';
+        this.filesToWatchCallback = (options.filesToWatchCallback || (files => files));
+    }
+
+    apply(compiler) {
+        // Create a separate watcher
+        compiler.hooks.watchRun.tapPromise('ZiggyWebpackPlugin', () => {
+            if (!this._init) {
+                this._init = true;
+                this.watcher = new Watchpack({ aggregateTimeout: 50, ...compiler.watching?.watchOptions });
+
+                let toWatch = [path.resolve(this.path, './routes/'), path.resolve(this.path, './config/ziggy.php')];
+                toWatch = this.filesToWatchCallback(toWatch) || toWatch;
+
+                // Run the generation command which in turn will trigger a rebuild if needed
+                this.watcher.on('aggregated', () => this._runCommand());
+
+                Promise.all(toWatch.map((file) => fs.promises.lstat(file).catch(() => null))).then((stats) => {
+                    const directories = [];
+                    const files = [];
+                    const missing = [];
+                    stats.forEach((stat, index) => (stat ? (stat.isDirectory() ? directories : files) : missing).push(toWatch[index]));
+
+                    this.watcher.watch({ files, directories, missing });
+                });
+                // Run the generation command before webpack compilation
+                return this._runCommand();
+            } else {
+                return Promise.resolve();
+            }
+        });
+        compiler.hooks.watchClose.tap('ZiggyWebpackPlugin', () => this.watcher.close());
+
+        // Run the generation command before webpack compilation when we're not watching
+        compiler.hooks.run.tapPromise('ZiggyWebpackPlugin', () => this._runCommand());
+    }
+
+    _runCommand() {
+        return typeof this.command === 'function' ? Promise.resolve(this.command()) :
+            new Promise((resolve, reject) => {
+                const process = exec(this.command);
+                process.stdout.on('data', (data) => {
+                    console.log(data);
+                });
+                process.stderr.on('data', (data) => {
+                    console.error(data);
+                });
+                process.on('exit', code => {
+                    if (code !== 0) {
+                        reject();
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+    }
+};


### PR DESCRIPTION
#522 Revisited with a webpack plugin instead

Usage
```js
const ZiggyWebpackPlugin = require('./vendor/tightenco/ziggy/webpackPlugin');
mix.webpackConfig({
  plugins: [new ZiggyWebpackPlugin('php artisan ziggy:generate')],
});
```

This runs the command passed to it before the compilation.
If running `mix watch`, it will also watch for changes in config/ziggy.php and routes/ to retrigger this same command which in turn will trigger a rebuild if those files are modified