### PR TITLE
Fix `route().current()` with wheres including regex start/end anchors

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -63,7 +63,7 @@ export default class Route {
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
             .replace(/(\/?){([^}?]*)(\??)}/g, (_, slash, segment, optional) => {
-                const regex = `(?<${segment}>${this.wheres[segment] || '[^/?]+'})`;
+                const regex = `(?<${segment}>${this.wheres[segment]?.replace(/(^\^)|(\$$)/g, '') || '[^/?]+'})`;
                 return optional ? `(${slash}${regex})?` : `${slash}${regex}`;
             })
             .replace(/^\w+:\/\//, '');

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -778,6 +778,27 @@ describe('current()', () => {
         deepEqual(route().params, {digit: '12', required: 'different_but_required', optional: 'optional', extension: undefined, ab: 'cd', ef: '1', 'dd': ''})
     });
 
+    test('can strip regex start and end of string tokens from wheres', () => {
+        global.Ziggy = undefined;
+        global.window.location.pathname = '/workspace/processes';
+
+        const config = {
+            url: 'https://ziggy.dev',
+            port: null,
+            routes: {
+                'workspaces.processes.index': {
+                    uri: '{workspace}/processes',
+                    methods: ['GET', 'HEAD'],
+                    wheres: {
+                        workspace: '^(?!api|nova-api|horizon).*$',
+                    },
+                },
+            },
+        };
+
+        same(route(undefined, undefined, undefined, config).current(), 'workspaces.processes.index');
+    });
+
     test('can check the current route name at a URL with a non-delimited parameter', () => {
         global.window.location.pathname = '/strict-download/file.html';
 


### PR DESCRIPTION
This PR updates Ziggy to strip any leading/trailing `^` and `$` regex anchor tokens from route parameter 'where' constraints before attempting to compile a route pattern. Previously, a route with something like `->where('parameter', '^(?!nova-api|nova-vendor)$')` would eventually end up with Ziggy's javascript attempting to match something like `ziggy.dev/(?<parameter>^(?!nova-api|nova-vendor)$)/path`, which would never match anything. Now, it produces `ziggy.dev/(?<parameter>(?!nova-api|nova-vendor))/path`.

Laravel (via Symfony) already strips these out before it does any route matching, so they're not actually doing anything there ([Symfony's `Route`](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Routing/Route.php#L431-L446), which [Laravel's `Route`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Routing/Route.php#L320) uses internally when matching). This PR brings Ziggy in line with this behaviour.

Fixes #534.