### PR TITLE
Fix inherited custom route key name detection

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -3,6 +3,7 @@
 namespace Tightenco\Ziggy;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
@@ -174,7 +175,7 @@ class Ziggy implements JsonSerializable
                     ? Reflector::getParameterClassName($parameter)
                     : $parameter->getType()->getName();
                 $override = (new ReflectionClass($model))->isInstantiable()
-                    && $model === (new ReflectionMethod($model, 'getRouteKeyName'))->class;
+                    && (new ReflectionMethod($model, 'getRouteKeyName'))->class !== Model::class;
 
                 // Avoid booting this model if it doesn't override the default route key name
                 $bindings[$parameter->getName()] = $override ? app($model)->getRouteKeyName() : 'id';

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -17,6 +17,9 @@ class RouteModelBindingTest extends TestCase
         $router->get('users/{user}', function (User $user) {
             return '';
         })->name('users');
+        $router->get('admins/{admin}', function (Admin $admin) {
+            return '';
+        })->name('admins');
         $router->get('tags/{tag}', function (Tag $tag) {
             return '';
         })->name('tags');
@@ -56,6 +59,22 @@ class RouteModelBindingTest extends TestCase
         ];
 
         $this->assertSame($expected, (new Ziggy)->filter('users')->toArray()['routes']);
+    }
+
+    /** @test */
+    public function register_inherited_custom_route_key_name()
+    {
+        $expected = [
+            'admins' => [
+                'uri' => 'admins/{admin}',
+                'methods' => ['GET', 'HEAD'],
+                'bindings' => [
+                    'admin' => 'uuid',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, (new Ziggy)->filter('admins')->toArray()['routes']);
     }
 
     /** @test */
@@ -255,4 +274,9 @@ class Tag extends Model
         parent::boot();
         static::$wasBooted = true;
     }
+}
+
+class Admin extends User
+{
+    //
 }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -158,6 +158,13 @@ class RouteModelBindingTest extends TestCase
                     'user' => 'uuid',
                 ],
             ],
+            'admins' => [
+                'uri' => 'admins/{admin}',
+                'methods' => ['GET', 'HEAD'],
+                'bindings' => [
+                    'admin' => 'uuid',
+                ],
+            ],
             'tags' => [
                 'uri' => 'tags/{tag}',
                 'methods' => ['GET', 'HEAD'],
@@ -207,7 +214,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"users.store":{"uri":"users","methods":["POST"]},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"url":"http:\/\/ziggy.dev","port":null,"defaults":{},"routes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"admins":{"uri":"admins\/{admin}","methods":["GET","HEAD"],"bindings":{"admin":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"users.store":{"uri":"users","methods":["POST"]},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }


### PR DESCRIPTION
This PR allows Ziggy to recognize custom route key names defined in traits and parent classes of the model bound into the route. Previously, we wouldn't use the custom route key name `uuid` for the `User` model in this scenario...

```php
class Model extends \Illuminate\Database\Eloquent\Model
{
    public function getRouteKeyName(): string
    {
        return 'uuid';
    }
}

class User extends Model
{
    //
}
```

...because in order to determine if a given model was using a custom route key name, we were checking if the class defining `getRouteKeyName()` was the exact class being bound into the route. But this fails if it's defined in a custom parent class, or a trait of a parent class.

In this PR we now check that the class defining `getRouteKeyName()` is **not** `Illuminate\Database\Eloquent\Model`, which should cover any situation where that method is being overridden anywhere at all.

Fixes #527.