### PR TITLE
Use global regex instead of `replaceAll`

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -93,7 +93,7 @@ export default class Route {
             }
 
             if (segments[segments.length - 1].name === segment && this.wheres[segment] === '.*') {
-                return encodeURIComponent(params[segment] ?? '').replaceAll('%2F', '/');
+                return encodeURIComponent(params[segment] ?? '').replace(/%2F/g, '/');
             }
 
             if (this.wheres[segment] && !new RegExp(`^${optional ? `(${this.wheres[segment]})?` : this.wheres[segment]}$`).test(params[segment] ?? '')) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -603,6 +603,7 @@ describe('route()', () => {
     test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
         same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four');
         same(route('slashes', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one%2Ftwo/Fun%26Games/venues');
+        same(route('slashes', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one%2Ftwo%2Fthree/Fun%26Games/venues/outdoors');
     });
 });
 


### PR DESCRIPTION
`.replaceAll()` is currently sitting at about 89% global browser support, which is a bit lower that I'd like ideally, and avoiding using it is easy. Fixes #546.