### PR TITLE
Add support for negating route filter patterns with `!`

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -19,13 +19,13 @@ class Ziggy implements JsonSerializable
     protected $group;
     protected $routes;
 
-    public function __construct($group = null, string $url = null)
+    public function __construct($group = NULL, string $url = NULL)
     {
         $this->group = $group;
 
         $this->url = rtrim($url ?? url('/'), '/');
 
-        if (! static::$cache) {
+        if (!static::$cache) {
             static::$cache = $this->nameKeyedRoutes();
         }
 
@@ -34,7 +34,7 @@ class Ziggy implements JsonSerializable
 
     public static function clearRoutes()
     {
-        static::$cache = null;
+        static::$cache = NULL;
     }
 
     private function applyFilters($group)
@@ -74,9 +74,14 @@ class Ziggy implements JsonSerializable
             return $this->filter($filters, true)->routes;
         }
 
+        if (config()->has("ziggy.groups.{$group}.only")) {
+            return $this->filter(config("ziggy.groups.{$group}.only"), true)->routes;
+        }
+
         if (config()->has("ziggy.groups.{$group}")) {
             return $this->filter(config("ziggy.groups.{$group}"), true)->routes;
         }
+
 
         return $this->routes;
     }
@@ -87,7 +92,7 @@ class Ziggy implements JsonSerializable
     public function filter($filters = [], $include = true): self
     {
         $this->routes = $this->routes->filter(function ($route, $name) use ($filters, $include) {
-            return Str::is(Arr::wrap($filters), $name) ? $include : ! $include;
+            return Str::is(Arr::wrap($filters), $name) ? $include : !$include;
         });
 
         return $this;
@@ -130,7 +135,7 @@ class Ziggy implements JsonSerializable
     {
         return [
             'url' => $this->url,
-            'port' => parse_url($this->url)['port'] ?? null,
+            'port' => parse_url($this->url)['port'] ?? NULL,
             'defaults' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],
@@ -144,7 +149,7 @@ class Ziggy implements JsonSerializable
     public function jsonSerialize(): array
     {
         return array_merge($routes = $this->toArray(), [
-            'defaults' => (object) $routes['defaults'],
+            'defaults' => (object)$routes['defaults'],
         ]);
     }
 
@@ -167,7 +172,7 @@ class Ziggy implements JsonSerializable
             $bindings = [];
 
             foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-                if (! in_array($parameter->getName(), $route->parameterNames())) {
+                if (!in_array($parameter->getName(), $route->parameterNames())) {
                     break;
                 }
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -99,9 +99,33 @@ class Ziggy implements JsonSerializable
      */
     public function filter($filters = [], $include = true): self
     {
-        $this->routes = $this->routes->filter(function ($route, $name) use ($filters, $include) {
-            return Str::is(Arr::wrap($filters), $name) ? $include : ! $include;
+        $filters = Arr::wrap($filters);
+
+        $reject = collect($filters)->every(function (string $pattern) {
+            return Str::startsWith($pattern, '!');
         });
+
+        $this->routes = $reject
+            ? $this->routes->reject(function ($route, $name) use ($filters) {
+                foreach ($filters as $pattern) {
+                    if (Str::is(substr($pattern, 1), $name)) {
+                        return true;
+                    }
+                }
+            })
+            : $this->routes->filter(function ($route, $name) use ($filters, $include) {
+                if ($include === false) {
+                    return ! Str::is($filters, $name);
+                }
+
+                foreach ($filters as $pattern) {
+                    if (Str::startsWith($pattern, '!') && Str::is(substr($pattern, 1), $name)) {
+                        return false;
+                    }
+                }
+
+                return Str::is($filters, $name);
+            });
 
         return $this;
     }

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -19,13 +19,13 @@ class Ziggy implements JsonSerializable
     protected $group;
     protected $routes;
 
-    public function __construct($group = NULL, string $url = NULL)
+    public function __construct($group = null, string $url = null)
     {
         $this->group = $group;
 
         $this->url = rtrim($url ?? url('/'), '/');
 
-        if (!static::$cache) {
+        if (! static::$cache) {
             static::$cache = $this->nameKeyedRoutes();
         }
 
@@ -34,7 +34,7 @@ class Ziggy implements JsonSerializable
 
     public static function clearRoutes()
     {
-        static::$cache = NULL;
+        static::$cache = null;
     }
 
     private function applyFilters($group)
@@ -100,7 +100,7 @@ class Ziggy implements JsonSerializable
     public function filter($filters = [], $include = true): self
     {
         $this->routes = $this->routes->filter(function ($route, $name) use ($filters, $include) {
-            return Str::is(Arr::wrap($filters), $name) ? $include : !$include;
+            return Str::is(Arr::wrap($filters), $name) ? $include : ! $include;
         });
 
         return $this;
@@ -143,7 +143,7 @@ class Ziggy implements JsonSerializable
     {
         return [
             'url' => $this->url,
-            'port' => parse_url($this->url)['port'] ?? NULL,
+            'port' => parse_url($this->url)['port'] ?? null,
             'defaults' => method_exists(app('url'), 'getDefaultParameters')
                 ? app('url')->getDefaultParameters()
                 : [],
@@ -157,7 +157,7 @@ class Ziggy implements JsonSerializable
     public function jsonSerialize(): array
     {
         return array_merge($routes = $this->toArray(), [
-            'defaults' => (object)$routes['defaults'],
+            'defaults' => (object) $routes['defaults'],
         ]);
     }
 
@@ -180,7 +180,7 @@ class Ziggy implements JsonSerializable
             $bindings = [];
 
             foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-                if (!in_array($parameter->getName(), $route->parameterNames())) {
+                if (! in_array($parameter->getName(), $route->parameterNames())) {
                     break;
                 }
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -68,27 +68,14 @@ class Ziggy implements JsonSerializable
             $filters = [];
 
             foreach ($group as $groupName) {
-                $filters = array_merge($filters, config("ziggy.groups.{$groupName}"));
+                $filters = array_merge($filters, Arr::wrap(config("ziggy.groups.{$groupName}")));
             }
 
-            return $this->filter($filters, true)->routes;
-        }
-
-        // return unfiltered routes if user set both config options.
-        if (config()->has("ziggy.groups.{$group}.except") && config()->has("ziggy.groups.{$group}.only")) {
-            return $this->routes;
-        }
-
-        if (config()->has("ziggy.groups.{$group}.except")) {
-            return $this->filter(config("ziggy.groups.{$group}.except"), false)->routes;
-        }
-
-        if (config()->has("ziggy.groups.{$group}.only")) {
-            return $this->filter(config("ziggy.groups.{$group}.only"), true)->routes;
+            return $this->filter($filters)->routes;
         }
 
         if (config()->has("ziggy.groups.{$group}")) {
-            return $this->filter(config("ziggy.groups.{$group}"), true)->routes;
+            return $this->filter(config("ziggy.groups.{$group}"))->routes;
         }
 
         return $this->routes;

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -74,6 +74,15 @@ class Ziggy implements JsonSerializable
             return $this->filter($filters, true)->routes;
         }
 
+        // return unfiltered routes if user set both config options.
+        if (config()->has("ziggy.groups.{$group}.except") && config()->has("ziggy.groups.{$group}.only")) {
+            return $this->routes;
+        }
+
+        if (config()->has("ziggy.groups.{$group}.except")) {
+            return $this->filter(config("ziggy.groups.{$group}.except"), false)->routes;
+        }
+
         if (config()->has("ziggy.groups.{$group}.only")) {
             return $this->filter(config("ziggy.groups.{$group}.only"), true)->routes;
         }
@@ -81,7 +90,6 @@ class Ziggy implements JsonSerializable
         if (config()->has("ziggy.groups.{$group}")) {
             return $this->filter(config("ziggy.groups.{$group}"), true)->routes;
         }
-
 
         return $this->routes;
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -235,25 +235,15 @@ class ZiggyTest extends TestCase
     /** @test */
     public function can_set_excluded_routes_using_groups_except_config()
     {
-        config(['ziggy.groups' => ['authors' => ['except' => ['home', 'posts.*']]]]);
+        config(['ziggy.groups' => ['authors' => ['except' => ['home', 'posts.*', 'postComments.*']]]]);
         $routes = (new Ziggy('authors'))->toArray()['routes'];
 
         $expected = [
-            'postComments.index' => [
-                'uri' => 'posts/{post}/comments',
-                'methods' => ['GET', 'HEAD'],
-            ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
             ],
-            'postComments.show' => [
-                'uri' => 'posts/{post}/comments/{comment}',
-                'methods' => ['GET', 'HEAD'],
-            ],
         ];
-
-        $this->addPostCommentsRouteWithBindings($expected);
 
         $this->assertSame($expected, $routes);
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -519,7 +519,7 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'url' => 'http://ziggy.dev',
-            'port' => NULL,
+            'port' => null,
             'defaults' => [],
             'routes' => [
                 'home' => [
@@ -561,7 +561,7 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'url' => 'http://ziggy.dev',
-            'port' => NULL,
+            'port' => null,
             'defaults' => [],
             'routes' => [
                 'postComments.index' => [

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -233,6 +233,75 @@ class ZiggyTest extends TestCase
     }
 
     /** @test */
+    public function can_set_excluded_routes_using_groups_except_config()
+    {
+        config(['ziggy.groups' => ['authors' => ['except' => ['home', 'posts.*']]]]);
+        $routes = (new Ziggy('authors'))->toArray()['routes'];
+
+        $expected = [
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+            ],
+        ];
+
+        $this->addPostCommentsRouteWithBindings($expected);
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /** @test */
+    public function returns_unfiltered_routes_when_both_only_and_except_configs_set_in_groups()
+    {
+        config(['ziggy.groups' => [
+            'authors' => [
+                'only' => ['home'],
+                'except' => ['posts.*'],
+            ]],
+        ]);
+        $routes = (new Ziggy('authors'))->toArray()['routes'];
+
+        $expected = [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+            ],
+        ];
+
+        $this->addPostCommentsRouteWithBindings($expected);
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /** @test */
     public function can_ignore_passed_group_not_set_in_config()
     {
         // The 'authors' group doesn't exist

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -205,6 +205,34 @@ class ZiggyTest extends TestCase
     }
 
     /** @test */
+    public function can_set_included_routes_using_groups_only_config()
+    {
+        config(['ziggy.groups' => ['authors' => ['only' => ['home', 'posts.*']]]]);
+        $routes = (new Ziggy('authors'))->toArray()['routes'];
+
+        $expected = [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+            ],
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /** @test */
     public function can_ignore_passed_group_not_set_in_config()
     {
         // The 'authors' group doesn't exist
@@ -432,7 +460,7 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'url' => 'http://ziggy.dev',
-            'port' => null,
+            'port' => NULL,
             'defaults' => [],
             'routes' => [
                 'home' => [
@@ -474,7 +502,7 @@ class ZiggyTest extends TestCase
 
         $expected = [
             'url' => 'http://ziggy.dev',
-            'port' => null,
+            'port' => NULL,
             'defaults' => [],
             'routes' => [
                 'postComments.index' => [


### PR DESCRIPTION
Adds support for filtering _out_ certain route names by prefixing a pattern with `!`. If all provided patterns are negated, the patterns are treated as 'reject' rules, starting with all routes included by default and using the patterns to filter them out, which is how `except` works now.

Addresses #520 and #555 because groups now support both including and excluding routes. The existing functionality behaves like `only`, so the key addition would be a way to exclude routes, which this PR accomplishes:

```php
// Current usage, behaves like `only`
config(['ziggy.groups' => [
    'viewer' => [
        'posts.*',
    ],
]]);

// Added in this PR, behaves like `except`
config(['ziggy.groups' => [
    'guest' => [
        '!posts.*',
    ],
]]);

// Also added in this PR—mix and match! Behaves like `only` but additionally excludes negated patterns
config(['ziggy.groups' => [
    'viewer' => [
        'posts.*',
        '!posts.comments.*',
    ],
]]);
```

This does make the top-level `except` key a bit redundant, but that lines up nicely with my plan in v2 to combine 'only', 'except', and 'groups' into one feature 👀 

@YeeJiaWei thoughts? Your original example in the discussion would now look like this:

```php
return [
    'groups' => [
        'inertia' => ['!_debugbar.*', '!debugbar.*', '!ignition.*', '!admin.*'],
    ],
];
```

Closes #555.