### PR TITLE
fix: route().params is not decoded

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -71,13 +71,12 @@ export default class Route {
         const [location, query] = url.replace(/^\w+:\/\//, '').split('?');
 
         const matches = new RegExp(`^${pattern}/?$`).exec(location);
-
+        
         if (matches) {
-            const params = {};
-            if (matches.groups) {
-                Object.keys(matches.groups).forEach(k => params[k] = typeof matches.groups[k] === 'string' ? decodeURIComponent(matches.groups[k]) : matches.groups[k]);
+            for (const k in matches.groups) {
+                matches.groups[k] = typeof matches.groups[k] === 'string' ? decodeURIComponent(matches.groups[k]) : matches.groups[k];
             }
-            return { params, query: parse(query) };
+            return { params: matches.groups, query: parse(query) };
         }
 
         return false;

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -72,7 +72,15 @@ export default class Route {
 
         const matches = new RegExp(`^${pattern}/?$`).exec(location);
 
-        return matches ? { params: matches.groups, query: parse(query) } : false;
+        if (matches) {
+            const params = {};
+            if (matches.groups) {
+                Object.keys(matches.groups).forEach(k => params[k] = typeof matches.groups[k] === 'string' ? decodeURIComponent(matches.groups[k]) : matches.groups[k]);
+            }
+            return { params, query: parse(query) };
+        }
+
+        return false;
     }
 
     /**

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -545,6 +545,13 @@ describe('route()', () => {
         deepEqual(route().params, { event: '1', venue: '2' });
     });
 
+    test('can extract encoded parameters from the current URL', () => {
+        global.window.location.href = 'https://ziggy.dev/events/1/venues/1%2B2%263';
+        global.window.location.pathname = '/events/1/venues/1%2B2%263';
+
+        deepEqual(route().params, { event: '1', venue: '1+2&3' });
+    });
+
     test('can extract query parameters from the current URL', () => {
         global.window.location.href = 'https://ziggy.dev/posts/1?guest[name]=Taylor';
         global.window.location.host = 'ziggy.dev';
@@ -553,11 +560,11 @@ describe('route()', () => {
 
         deepEqual(route().params, { post: '1', guest: { name: 'Taylor' } });
 
-        global.window.location.href = 'https://ziggy.dev/events/1/venues/2?id=5&vip=0';
+        global.window.location.href = 'https://ziggy.dev/events/1/venues/2?id=5&vip=1%2B2%263';
         global.window.location.pathname = '/events/1/venues/2';
-        global.window.location.search = '?id=5&vip=0';
+        global.window.location.search = '?id=5&vip=1%2B2%263';
 
-        deepEqual(route().params, { event: '1', venue: '2', id: '5', vip: '0' });
+        deepEqual(route().params, { event: '1', venue: '2', id: '5', vip: '1+2&3' });
     });
 
     test("can append 'extra' string/number parameter to query", () => {
@@ -569,8 +576,8 @@ describe('route()', () => {
 
     test("can append 'extra' string/number elements in array of parameters to query", () => {
         // 'posts.show' has exactly one parameter
-         same(route('posts.show', [1, 2]), 'https://ziggy.dev/posts/1?2=');
-         same(route('posts.show', ['my-first-post', 'foo', 'bar']), 'https://ziggy.dev/posts/my-first-post?foo=&bar=');
+        same(route('posts.show', [1, 2]), 'https://ziggy.dev/posts/1?2=');
+        same(route('posts.show', ['my-first-post', 'foo', 'bar']), 'https://ziggy.dev/posts/my-first-post?foo=&bar=');
     });
 
     test("can automatically append object with only 'extra' parameters to query", () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -545,7 +545,7 @@ describe('route()', () => {
         deepEqual(route().params, { event: '1', venue: '2' });
     });
 
-    test('can extract encoded parameters from the current URL', () => {
+    test('can decode parameters in the current URL', () => {
         global.window.location.href = 'https://ziggy.dev/events/1/venues/1%2B2%263';
         global.window.location.pathname = '/events/1/venues/1%2B2%263';
 


### PR DESCRIPTION
When params in the url are encoded (which they should be), they are not decoded

This is not the case for the query params

Params in url should be decoded, which this PR fixes