### PR TITLE
Trim slashes between origin and optional first param

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -26,13 +26,15 @@ export default class Route {
      * @return {String} Route template.
      */
     get template() {
+        return `${this.origin}/${this.definition.uri}`.replace(/\/+$/, '');
+    }
+    
+    get origin() {
         // If  we're building just a path there's no origin, otherwise: if this route has a
         // domain configured we construct the origin with that, if not we use the app URL
-        const origin = !this.config.absolute ? '' : this.definition.domain
+        return !this.config.absolute ? '' : this.definition.domain
             ? `${this.config.url.match(/^\w+:\/\//)[0]}${this.definition.domain}${this.config.port ? `:${this.config.port}` : ''}`
             : this.config.url;
-
-        return `${origin}/${this.definition.uri}`.replace(/\/+$/, '');
     }
 
     /**
@@ -101,6 +103,6 @@ export default class Route {
             }
 
             return encodeURIComponent(params[segment] ?? '');
-        }).replace(/\/+$/, '');
+        }).replace(`${this.origin}//`, `${this.origin}/`).replace(/\/+$/, '');
     }
 }

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -28,7 +28,15 @@ export default class Route {
     get template() {
         return `${this.origin}/${this.definition.uri}`.replace(/\/+$/, '');
     }
-    
+
+    /**
+     * Get a template of the origin for this route.
+     *
+     * @example
+     * https://{team}.ziggy.dev/
+     *
+     * @return {String} Route origin template.
+     */
     get origin() {
         // If  we're building just a path there's no origin, otherwise: if this route has a
         // domain configured we construct the origin with that, if not we use the app URL

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -612,4 +612,19 @@ class ZiggyTest extends TestCase
 
         $this->assertSame($routes, (new Ziggy)->toArray()['routes']);
     }
+
+    /** @test */
+    public function optional_params_inside_path()
+    {
+        app('router')->get('{country?}/test/{language?}/products/{id}', $this->noop())->name('products.show');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        $this->assertSame('http://ziggy.dev/ca/test/fr/products/1', route('products.show', ['country' => 'ca', 'language' => 'fr', 'id' => 1]));
+        // Optional param in the middle of a path
+        $this->assertSame('http://ziggy.dev/ca/test//products/1', route('products.show', ['country' => 'ca', 'id' => 1]));
+        // Optional param at the beginning of a path
+        $this->assertSame('http://ziggy.dev/test/fr/products/1', route('products.show', ['language' => 'fr', 'id' => 1]));
+        // Both
+        $this->assertSame('http://ziggy.dev/test//products/1', route('products.show', ['id' => 1]));
+    }
 }

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -383,6 +383,15 @@ describe('route()', () => {
         same(route('pages.optional', null), 'https://ziggy.dev/optionalpage');
     });
 
+    test('missing optional parameter in first path segment', () => {
+        same(route('products.show', { country: 'ca', language: 'fr', id: 1 }), 'https://ziggy.dev/ca/fr/products/1');
+        // These URLs aren't valid but this matches the behavior of Laravel's PHP `route()` helper
+        same(route('products.show', { country: 'ca', id: 1 }), 'https://ziggy.dev/ca//products/1');
+        same(route('products.show', { id: 1 }), 'https://ziggy.dev//products/1');
+        // First param is handled correctly
+        same(route('products.show', { language: 'fr', id: 1 }), 'https://ziggy.dev/fr/products/1');
+    });
+
     test('can error if a route name doesn’t exist', () => {
         throws(() => route('unknown-route'), /Ziggy error: route 'unknown-route' is not in the route list\./);
     });


### PR DESCRIPTION
This PR ensures that there is only ever exactly one slash (`/`) between a generated URL's origin and path. This fixes an issue where it was possible to end up with a double slash if the very first segment of the path is an optional, omitted, route parameter. For example, `{locale?}/foo` could generate `domain.com//foo` if the `locale` param wasn't provided.

**Note:** This PR intentionally does _not_ change the behaviour of omitted optional route params inside the route path. It's still possible to get double slashes there, e.g. with something like `/foo/{param?}/bar`, but this matches the behaviour of Laravel's `route()` function.

Resolves the issue discussed in #616. See https://github.com/tighten/ziggy/discussions/616#discussioncomment-5620680.