### PR TITLE
Allow setting URL in config

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -11,7 +11,7 @@ class BladeRouteGenerator
 
     public function generate($group = null, $nonce = null)
     {
-        $ziggy = new Ziggy($group);
+        $ziggy = new Ziggy($group, config('ziggy.url', null));
 
         $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 


### PR DESCRIPTION
A very simply fix that allows setting the URL in the `config/ziggy.php` file like so:

```php
<?php
return [
    'url' => env('APP_URL'),
];
```