### PR TITLE
Fix numeric route names

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -133,19 +133,20 @@ class Ziggy implements JsonSerializable
 
         $bindings = $this->resolveBindings($routes->toArray());
 
-        return $routes->merge($fallbacks)
-            ->map(function ($route) use ($bindings) {
-                return collect($route)->only(['uri', 'methods', 'wheres'])
-                    ->put('domain', $route->domain())
-                    ->put('bindings', $bindings[$route->getName()] ?? [])
-                    ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
-                        if (is_array($middleware)) {
-                            return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values()->all());
-                        }
+        $fallbacks->map(fn ($route, $name) => $routes->put($name, $route));
 
-                        return $collection->put('middleware', $route->middleware());
-                    })->filter();
-            });
+        return $routes->map(function ($route) use ($bindings) {
+            return collect($route)->only(['uri', 'methods', 'wheres'])
+                ->put('domain', $route->domain())
+                ->put('bindings', $bindings[$route->getName()] ?? [])
+                ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
+                    if (is_array($middleware)) {
+                        return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values()->all());
+                    }
+
+                    return $collection->put('middleware', $route->middleware());
+                })->filter();
+        });
     }
 
     /**

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -133,7 +133,9 @@ class Ziggy implements JsonSerializable
 
         $bindings = $this->resolveBindings($routes->toArray());
 
-        $fallbacks->map(fn ($route, $name) => $routes->put($name, $route));
+        $fallbacks->map(function ($route, $name) use ($routes) {
+            $routes->put($name, $route);
+        });
 
         return $routes->map(function ($route) use ($bindings) {
             return collect($route)->only(['uri', 'methods', 'wheres'])

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -652,4 +652,38 @@ class ZiggyTest extends TestCase
         $this->assertArrayNotHasKey('foo.bar', (new Ziggy)->toArray()['routes']);
         $this->assertArrayNotHasKey('foo.bar.baz', (new Ziggy)->toArray()['routes']);
     }
+
+    /** @test */
+    public function numeric_route_names()
+    {
+        app('router')->get('a', $this->noop())->name('a');
+        app('router')->get('3', $this->noop())->name('3');
+        app('router')->get('b', $this->noop())->name('b');
+        app('router')->fallback($this->noop())->name('404');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        config(['ziggy.except' => ['home', 'posts.*', 'postComments.*', 'admin.*']]);
+
+        $this->assertSame([
+            'a' => [
+                'uri' => 'a',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            3 => [
+                'uri' => '3',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'b' => [
+                'uri' => 'b',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            404 => [
+                'uri' => '{fallbackPlaceholder}',
+                'methods' => ['GET', 'HEAD'],
+                'wheres' => [
+                    'fallbackPlaceholder' => '.*',
+                ],
+            ],
+        ], (new Ziggy)->toArray()['routes']);
+    }
 }


### PR DESCRIPTION
The Collection `->merge()` method calls `array_merge()` under the hood, which re-numbers numeric array keys starting at 0. This PR adds fallback routes back into the route list one by one manually, so that we never call `->merge()` and all numeric keys are preserved.

Fixes #657.