### PR TITLE
Make slash "not encoding" less restrictive

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -81,7 +81,7 @@ export default class Route {
         const [location, query] = url.replace(/^\w+:\/\//, '').split('?');
 
         const matches = new RegExp(`^${pattern}/?$`).exec(location);
-        
+
         if (matches) {
             for (const k in matches.groups) {
                 matches.groups[k] = typeof matches.groups[k] === 'string' ? decodeURIComponent(matches.groups[k]) : matches.groups[k];
@@ -109,12 +109,12 @@ export default class Route {
                 throw new Error(`Ziggy error: '${segment}' parameter is required for route '${this.name}'.`)
             }
 
-            if (segments[segments.length - 1].name === segment && this.wheres[segment] === '.*') {
-                return encodeURIComponent(params[segment] ?? '').replace(/%2F/g, '/');
-            }
+            if (this.wheres[segment]) {
+                if(!new RegExp(`^${optional ? `(${this.wheres[segment]})?` : this.wheres[segment]}$`).test(params[segment] ?? '')) {
+                    throw new Error(`Ziggy error: '${segment}' parameter does not match required format '${this.wheres[segment]}' for route '${this.name}'.`)
+                }
 
-            if (this.wheres[segment] && !new RegExp(`^${optional ? `(${this.wheres[segment]})?` : this.wheres[segment]}$`).test(params[segment] ?? '')) {
-                throw new Error(`Ziggy error: '${segment}' parameter does not match required format '${this.wheres[segment]}' for route '${this.name}'.`)
+                return encodeURIComponent(params[segment] ?? '').replace(/%2F/g, '/');
             }
 
             return encodeURIComponent(params[segment] ?? '');

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -110,7 +110,7 @@ export default class Route {
             }
 
             if (this.wheres[segment]) {
-                if(!new RegExp(`^${optional ? `(${this.wheres[segment]})?` : this.wheres[segment]}$`).test(params[segment] ?? '')) {
+                if (!new RegExp(`^${optional ? `(${this.wheres[segment]})?` : this.wheres[segment]}$`).test(params[segment] ?? '')) {
                     throw new Error(`Ziggy error: '${segment}' parameter does not match required format '${this.wheres[segment]}' for route '${this.name}'.`)
                 }
 

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -114,7 +114,9 @@ export default class Route {
                     throw new Error(`Ziggy error: '${segment}' parameter does not match required format '${this.wheres[segment]}' for route '${this.name}'.`)
                 }
 
-                return encodeURIComponent(params[segment] ?? '').replace(/%2F/g, '/');
+                if (segments[segments.length - 1].name === segment) {
+                    return encodeURIComponent(params[segment] ?? '').replace(/%2F/g, '/');
+                }
             }
 
             return encodeURIComponent(params[segment] ?? '');

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -647,7 +647,7 @@ describe('route()', () => {
         same(route('slashesOtherRegex', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one%2Ftwo%2Fthree/Fun%26Games/venues/outdoors');
     });
 
-    test('skip encoding slashes inside middle parameter when explicitly allowed', () => {
+    test.skip('skip encoding slashes inside middle parameter when explicitly allowed', () => {
         same(route('slashesMiddleParam', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one/two/three/four');
         same(route('slashesMiddleParam', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one/two/Fun%26Games/venues');
         same(route('slashesMiddleParam', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one/two/three/Fun%26Games/venues/outdoors');

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -198,6 +198,21 @@ const defaultZiggy = {
                 slug: '.*',
             },
         },
+        slashesOtherRegex: {
+            uri: 'slashes/{encoded}/{slug}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                slug: '.+',
+            },
+        },
+        slashesMiddleParam: {
+            uri: 'slashes/{encoded}/{slug}',
+            methods: ['GET', 'HEAD'],
+            wheres: {
+                encoded: '.+',
+                slug: '.+',
+            },
+        },
     },
 };
 
@@ -622,11 +637,20 @@ describe('route()', () => {
         throws(() => route('pages.requiredExtensionWhere', { extension: '.pdf' }), /'extension' parameter does not match required format/);
     });
 
-
-    test('can skip encoding slashes inside last parameter when explicitly allowed', () => {
+    test('skip encoding slashes inside last parameter when explicitly allowed', () => {
         same(route('slashes', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four');
         same(route('slashes', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one%2Ftwo/Fun%26Games/venues');
         same(route('slashes', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one%2Ftwo%2Fthree/Fun%26Games/venues/outdoors');
+
+        same(route('slashesOtherRegex', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one%2Ftwo/three/four');
+        same(route('slashesOtherRegex', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one%2Ftwo/Fun%26Games/venues');
+        same(route('slashesOtherRegex', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one%2Ftwo%2Fthree/Fun%26Games/venues/outdoors');
+    });
+
+    test('skip encoding slashes inside middle parameter when explicitly allowed', () => {
+        same(route('slashesMiddleParam', ['one/two', 'three/four']), 'https://ziggy.dev/slashes/one/two/three/four');
+        same(route('slashesMiddleParam', ['one/two', 'Fun&Games/venues']), 'https://ziggy.dev/slashes/one/two/Fun%26Games/venues');
+        same(route('slashesMiddleParam', ['one/two/three', 'Fun&Games/venues/outdoors']), 'https://ziggy.dev/slashes/one/two/three/Fun%26Games/venues/outdoors');
     });
 });
 


### PR DESCRIPTION
### The problem
Following up on #500. This feature is great but too restrictive:
- The [docs](https://laravel.com/docs/10.x/routing#parameters-encoded-forward-slashes) state the "Encoded forward slashes are only supported within the last route segment." but in reality Laravel route generator doesn't encode slashes by default for all params (cf. [RouteUrlGenerator](https://github.com/laravel/framework/blob/85ad68cb0bcb5143e0e915098097c6d23ea22e7e/src/Illuminate/Routing/RouteUrlGenerator.php#L37))
- The `where` regex can be different than `.*`

Example:

```php
Route::get('/{breadcrumb}/page/{page}')->where('breadcrumb', '.+');
```
### Proposed solution
I move the `/` replacement after asserting the current param matches the given `wheres`. At this point if slashes are replaced it's because the RegExp allowed so.