### PR TITLE
Fix empty root URL with `absolute: false`

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -26,7 +26,9 @@ export default class Route {
      * @return {String} Route template.
      */
     get template() {
-        return `${this.origin}/${this.definition.uri}`.replace(/(?<=.)\/+$/, '');
+        const template = `${this.origin}/${this.definition.uri}`.replace(/\/+$/, '');
+
+        return template === '' ? '/' : template;
     }
 
     /**

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -26,7 +26,7 @@ export default class Route {
      * @return {String} Route template.
      */
     get template() {
-        return `${this.origin}/${this.definition.uri}`.replace(/\/+$/, '');
+        return `${this.origin}/${this.definition.uri}`.replace(/(?<=.)\/+$/, '');
     }
 
     /**

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -376,6 +376,10 @@ describe('route()', () => {
         same(route('home'), 'https://ziggy.dev');
     });
 
+    test('can generate a relative URL to a root path', () => {
+        same(route('home', undefined, false), '/');
+    });
+
     // @todo duplicate
     test('can ignore an optional parameter', () => {
         same(route('optional', { id: 123 }), 'https://ziggy.dev/optional/123');


### PR DESCRIPTION
Fixes #666. Wanted to use a Regex lookbehind but support for them was only added to Safari several months ago and that's cutting it a bit close I think. That being said, the strings Ziggy works with are so short that we probably don't need to worry about performance at all, so we could probably lean on advanced Regex functionality more... 