### PR TITLE
Fix `route().current()` with encoded characters

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -90,7 +90,7 @@ export default class Route {
 
         const [location, query] = url.replace(/^\w+:\/\//, '').split('?');
 
-        const matches = new RegExp(`^${pattern}/?$`).exec(location);
+        const matches = new RegExp(`^${pattern}/?$`).exec(decodeURI(location));
 
         if (matches) {
             for (const k in matches.groups) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1236,15 +1236,16 @@ describe('current()', () => {
     test('can check the current route with Cyrillic characters', () => {
         global.window.location.pathname = '/статистика';
 
-        same(route().current(), 'statistics');
-        assert(route().current('statistics'));
+        expect(route().current()).toBe('statistics');
+        expect(route().current('statistics')).toBe(true);
     });
 
     test('can check the current route with encoded Cyrillic characters', () => {
-        global.window.location.pathname = '/%D1%81%D1%82%D0%B0%D1%82%D0%B8%D1%81%D1%82%D0%B8%D0%BA%D0%B0';
+        global.window.location.pathname =
+            '/%D1%81%D1%82%D0%B0%D1%82%D0%B8%D1%81%D1%82%D0%B8%D0%BA%D0%B0';
 
-        same(route().current(), 'statistics');
-        assert(route().current('statistics'));
+        expect(route().current()).toBe('statistics');
+        expect(route().current('statistics')).toBe(true);
     });
 
     test('can ignore routes that don’t allow GET requests', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -184,6 +184,10 @@ const defaultZiggy = {
                 extension: '\\.(php|html)',
             },
         },
+        statistics: {
+            uri: 'статистика',
+            methods: ['GET', 'HEAD'],
+        },
         pages: {
             uri: '{page}',
             methods: ['GET', 'HEAD'],
@@ -1227,6 +1231,20 @@ describe('current()', () => {
             }),
         ).toBe(false);
         expect(route().current('events.venues.show', { id: 12, user: 'Matt' })).toBe(false);
+    });
+
+    test('can check the current route with Cyrillic characters', () => {
+        global.window.location.pathname = '/статистика';
+
+        same(route().current(), 'statistics');
+        assert(route().current('statistics'));
+    });
+
+    test('can check the current route with encoded Cyrillic characters', () => {
+        global.window.location.pathname = '/%D1%81%D1%82%D0%B0%D1%82%D0%B8%D1%81%D1%82%D0%B8%D0%BA%D0%B0';
+
+        same(route().current(), 'statistics');
+        assert(route().current('statistics'));
     });
 
     test('can ignore routes that don’t allow GET requests', () => {


### PR DESCRIPTION
This PR decodes the window location before trying to match it against route patterns. The issue here is that a URL like `http://example.com/статистика`, although it'll show up exactly like that in most browsers, is actually interpreted by the browser and by JavaScript as `http://example.com/%D1%81%D1%82%D0%B0%D1%82%D0%B8%D1%81%D1%82%D0%B8%D0%BA%D0%B0`, so that's what Ziggy sees too.

The fix in this PR does work, but I'm still a bit uneasy about it because I'm not sure what else it might affect unintentionally. Might add more tests or sit on it for a bit.

Fixes #665.