### PR TITLE
Handle generated file extensions more robustly

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -33,20 +33,26 @@ class CommandRouteGenerator extends Command
     {
         $ziggy = new Ziggy($this->option('group'), $this->option('url') ? url($this->option('url')) : null);
 
-        $this->makeDirectory(
-            $path = $this->argument('path') ?? config('ziggy.output.path', 'resources/js/ziggy.js')
-        );
+        $path = $this->argument('path') ?? config('ziggy.output.path', 'resources/js/ziggy.js');
+
+        if ($this->files->isDirectory(base_path($path))) {
+            $path .= '/ziggy';
+        } else {
+            $this->makeDirectory($path);
+        }
+
+        $name = preg_replace('/(\.d)?\.ts$|\.js$/', '', $path);
 
         if (! $this->option('types-only')) {
             $output = config('ziggy.output.file', File::class);
 
-            $this->files->put(base_path($path), new $output($ziggy));
+            $this->files->put(base_path("{$name}.js"), new $output($ziggy));
         }
 
         if ($this->option('types') || $this->option('types-only')) {
             $types = config('ziggy.output.types', Types::class);
 
-            $this->files->put(base_path(Str::replaceLast('.js', '.d.ts', $path)), new $types($ziggy));
+            $this->files->put(base_path("{$name}.d.ts"), new $types($ziggy));
         }
 
         $this->info('Files generated!');

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -217,7 +217,7 @@ class CommandRouteGeneratorTest extends TestCase
     /** @test */
     public function can_generate_correct_file_extensions_from_js_path_argument()
     {
-        Artisan::call('ziggy:generate resources/scripts/x.js --types');
+        Artisan::call('ziggy:generate', ['path' => 'resources/scripts/x.js', '--types' => true]);
 
         $this->assertFileExists(base_path('resources/scripts/x.js'));
         $this->assertFileExists(base_path('resources/scripts/x.d.ts'));
@@ -226,7 +226,7 @@ class CommandRouteGeneratorTest extends TestCase
     /** @test */
     public function can_generate_correct_file_extensions_from_ts_path_argument()
     {
-        Artisan::call('ziggy:generate resources/scripts/y.ts --types');
+        Artisan::call('ziggy:generate', ['path' => 'resources/scripts/y.ts', '--types' => true]);
 
         $this->assertFileExists(base_path('resources/scripts/y.js'));
         $this->assertFileExists(base_path('resources/scripts/y.d.ts'));
@@ -235,7 +235,7 @@ class CommandRouteGeneratorTest extends TestCase
     /** @test */
     public function can_generate_correct_file_extensions_from_dts_path_argument()
     {
-        Artisan::call('ziggy:generate resources/scripts/z.d.ts --types');
+        Artisan::call('ziggy:generate', ['path' => 'resources/scripts/z.d.ts', '--types' => true]);
 
         $this->assertFileExists(base_path('resources/scripts/z.js'));
         $this->assertFileExists(base_path('resources/scripts/z.d.ts'));
@@ -244,7 +244,7 @@ class CommandRouteGeneratorTest extends TestCase
     /** @test */
     public function can_generate_correct_file_extensions_from_ambiguous_path_argument()
     {
-        Artisan::call('ziggy:generate resources/scripts/foo --types');
+        Artisan::call('ziggy:generate', ['path' => 'resources/scripts/foo', '--types' => true]);
 
         $this->assertFileExists(base_path('resources/scripts/foo.js'));
         $this->assertFileExists(base_path('resources/scripts/foo.d.ts'));
@@ -253,7 +253,7 @@ class CommandRouteGeneratorTest extends TestCase
     /** @test */
     public function can_generate_correct_file_extensions_from_directory_path_argument()
     {
-        Artisan::call('ziggy:generate resources/js --types');
+        Artisan::call('ziggy:generate', ['path' => 'resources/js', '--types' => true]);
 
         $this->assertFileExists(base_path('resources/js/ziggy.js'));
         $this->assertFileExists(base_path('resources/js/ziggy.d.ts'));

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -213,6 +213,51 @@ class CommandRouteGeneratorTest extends TestCase
         $this->assertFileExists(base_path('resources/js/custom.d.ts'));
         $this->assertFileNotExists(base_path('resources/js/ziggy.d.ts'));
     }
+
+    /** @test */
+    public function can_generate_correct_file_extensions_from_js_path_argument()
+    {
+        Artisan::call('ziggy:generate resources/scripts/x.js --types');
+
+        $this->assertFileExists(base_path('resources/scripts/x.js'));
+        $this->assertFileExists(base_path('resources/scripts/x.d.ts'));
+    }
+
+    /** @test */
+    public function can_generate_correct_file_extensions_from_ts_path_argument()
+    {
+        Artisan::call('ziggy:generate resources/scripts/y.ts --types');
+
+        $this->assertFileExists(base_path('resources/scripts/y.js'));
+        $this->assertFileExists(base_path('resources/scripts/y.d.ts'));
+    }
+
+    /** @test */
+    public function can_generate_correct_file_extensions_from_dts_path_argument()
+    {
+        Artisan::call('ziggy:generate resources/scripts/z.d.ts --types');
+
+        $this->assertFileExists(base_path('resources/scripts/z.js'));
+        $this->assertFileExists(base_path('resources/scripts/z.d.ts'));
+    }
+
+    /** @test */
+    public function can_generate_correct_file_extensions_from_ambiguous_path_argument()
+    {
+        Artisan::call('ziggy:generate resources/scripts/foo --types');
+
+        $this->assertFileExists(base_path('resources/scripts/foo.js'));
+        $this->assertFileExists(base_path('resources/scripts/foo.d.ts'));
+    }
+
+    /** @test */
+    public function can_generate_correct_file_extensions_from_directory_path_argument()
+    {
+        Artisan::call('ziggy:generate resources/js --types');
+
+        $this->assertFileExists(base_path('resources/js/ziggy.js'));
+        $this->assertFileExists(base_path('resources/js/ziggy.d.ts'));
+    }
 }
 
 class CustomFileFormatter extends File


### PR DESCRIPTION
This PR allows the `ziggy:generate` command to handle a wider range of `path` argument formats and still create the right files with the right extensions.

Before this PR, the path argument had to be a file name ending in `.js`. That makes sense if you're generating Ziggy's JavaScript config file, but not so much if you're generating its types too, and even less so if you're generating _just_ its types on their own.

Now, the extension of the path argument is mostly ignored and we just use the argument to figure out the file path and name. Path arguments ending in `.js`, `.d.ts`, `.ts`, or even no extension, all generate the requested `.js` and/or `.d.ts` file at the base filename specified. As an added convenience, if the path argument happens to point to an existing directory, `ziggy.js` and/or `ziggy.d.ts` files will be generated inside that directory instead.

This all applies to output paths set via config instead of arguments too.

See #680.

@lmeysel thoughts?