### PR TITLE
Use fresh routes from HandleInertiaRequest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "guilheb/ziggy",
+    "name": "tightenco/ziggy",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tightenco/ziggy",
+    "name": "guilheb/ziggy",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "keywords": [
         "laravel",

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -1,7 +1,10 @@
 import route from './index.js';
+import { usePage } from '@inertiajs/vue3';
 
 export const ZiggyVue = {
     install(app, options) {
+        options = options ?? usePage().props?.ziggy;
+
         const r = (name, params, absolute, config = options) =>
             route(name, params, absolute, config);
 

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -3,9 +3,8 @@ import { usePage } from '@inertiajs/vue3';
 
 export const ZiggyVue = {
     install(app, options) {
-        options = options ?? usePage().props?.ziggy;
-
         const r = (name, params, absolute, config = options) =>
+            config = config ?? usePage().props?.ziggy;
             route(name, params, absolute, config);
 
         app.mixin({

--- a/src/js/vue.js
+++ b/src/js/vue.js
@@ -3,9 +3,10 @@ import { usePage } from '@inertiajs/vue3';
 
 export const ZiggyVue = {
     install(app, options) {
-        const r = (name, params, absolute, config = options) =>
+        const r = (name, params, absolute, config = options) => {
             config = config ?? usePage().props?.ziggy;
             route(name, params, absolute, config);
+        };
 
         app.mixin({
             methods: {


### PR DESCRIPTION
As discussed in https://github.com/tighten/ziggy/discussions/696, it would be really nice for the `route()` function to always have up-to-date routes.

The simplest use-case is having a small set of routes for the whole world to see (login, registration, etc) and then have access to all routes once a user is logged in. This is easily achievable in HandleInertiaRequest, but the JavaScript object is never updated. This PR ensure the `route()` function uses the fresh list of routes.