### PR TITLE
Export the types file

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     ],
     "type": "module",
     "source": "./src/js/index.js",
-    "exports": "./dist/index.js",
+    "exports": {
+        "default": "./dist/index.js",
+        "types": "./src/js/index.d.ts"
+    },
     "module": "./dist/index.esm.js",
     "types": "./src/js/index.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "type": "module",
     "source": "./src/js/index.js",
     "exports": {
-        "default": "./dist/index.js",
-        "types": "./src/js/index.d.ts"
+        "types": "./src/js/index.d.ts",
+        "default": "./dist/index.js"
     },
     "module": "./dist/index.esm.js",
     "types": "./src/js/index.d.ts",


### PR DESCRIPTION
If there is an `exports` key set, Typescript requires the types file to be included in the list of the files exported.

Without this change, Typescript errors when trying to import types with:
```
error TS7016: Could not find a declaration file for module 'ziggy-js'. '/.../node_modules/ziggy-js/dist/index.js' implicitly has an 'any' type.
  There are types at '/.../node_modules/ziggy-js/src/js/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'ziggy-js' library may need to update its package.json or typings.
```