### PR TITLE
Don't write to the output files if they have not changed at all

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -46,13 +46,19 @@ class CommandRouteGenerator extends Command
         if (! $this->option('types-only')) {
             $output = config('ziggy.output.file', File::class);
 
-            $this->files->put(base_path("{$name}.js"), new $output($ziggy));
+            $content = new $output($ziggy);
+            if ($this->files->get(base_path("${name}.js")) !== (string)$content) {
+                $this->files->put(base_path("{$name}.js"), $content);
+            }
         }
 
         if ($this->option('types') || $this->option('types-only')) {
             $types = config('ziggy.output.types', Types::class);
 
-            $this->files->put(base_path("{$name}.d.ts"), new $types($ziggy));
+            $content = new $types($ziggy);
+            if ($this->files->get(base_path("${name}.d.ts")) !== (string)$content) {
+                $this->files->put(base_path("{$name}.d.ts"), $content);
+            }
         }
 
         $this->info('Files generated!');

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -46,18 +46,20 @@ class CommandRouteGenerator extends Command
         if (! $this->option('types-only')) {
             $output = config('ziggy.output.file', File::class);
 
+            $file = base_path("${name}.js");
             $content = new $output($ziggy);
-            if ($this->files->get(base_path("${name}.js")) !== (string)$content) {
-                $this->files->put(base_path("{$name}.js"), $content);
+            if (!$this->files->exists($file) || $this->files->get($file) !== (string)$content) {
+                $this->files->put($file, $content);
             }
         }
 
         if ($this->option('types') || $this->option('types-only')) {
             $types = config('ziggy.output.types', Types::class);
 
+            $file = base_path("${name}.d.ts");
             $content = new $types($ziggy);
-            if ($this->files->get(base_path("${name}.d.ts")) !== (string)$content) {
-                $this->files->put(base_path("{$name}.d.ts"), $content);
+            if (! $this->files->exists($file) || $this->files->get($file) !== (string)$content) {
+                $this->files->put($file, $content);
             }
         }
 


### PR DESCRIPTION
When trying to include the `ziggy:generate` run as part of `webpack` (via `webpack-watch-files-plugin` and `hook-shell-script-webpack-plugin`), `ziggy:generate` will always write the output files even if there are no changes to the source routes file(s), which will then cause `webpack` to see a change to some of the source files that are being watched, which will trigger `ziggy:generate` to run again, causing an infinite loop.