### PR TITLE
Support Laravel Folio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+      - run: composer remove laravel/folio --dev --no-update --no-interaction
+        if: matrix.laravel == 9
       - run: composer require laravel/framework:"${{ matrix.laravel }}.*" --no-update --no-interaction
       - uses: ramsey/composer-install@v2
         with:

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "laravel/framework": ">=9.0"
     },
     "require-dev": {
+        "laravel/folio": "^1.1",
         "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
         "phpunit/phpunit": "^9.5 || ^10.3"
     },

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -240,7 +240,7 @@ class Ziggy implements JsonSerializable
         if (app()->has(FolioRoutes::class)) {
             $mountPaths = app(FolioManager::class)->mountPaths();
 
-            // Use already-registered named Folio routes (not all relevant view files) to respect route caching
+            // Use already-registered named Folio routes (instead of searching for all relevant view files) to respect route caching
             return collect(app(FolioRoutes::class)->routes())->map(function (array $route) use ($mountPaths) {
                 $uri = rtrim($route['baseUri'], '/') . str_replace($route['mountPath'], '', $route['path']);
                 $uri = str_replace('.blade.php', '', $uri);
@@ -278,7 +278,6 @@ class Ziggy implements JsonSerializable
                 return array_filter([
                     'uri' => $uri === '' ? '/' : trim($uri, '/'),
                     'methods' => ['GET'],
-                    // 'wheres' => [],
                     'domain' => $route['domain'],
                     'parameters' => $parameters,
                     'bindings' => $bindings,

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -142,10 +142,8 @@ class Ziggy implements JsonSerializable
             $routes->put($name, $route);
         });
 
-        $allRoutes = $this->folioRoutes();
-
-        $routes->map(function ($route, $name) use ($bindings, $allRoutes) {
-            $allRoutes->put(
+        return tap($this->folioRoutes(), fn ($all) => $routes->each(
+            fn ($route, $name) => $all->put(
                 $name,
                 collect($route)->only(['uri', 'methods', 'wheres'])
                     ->put('domain', $route->domain())
@@ -159,10 +157,8 @@ class Ziggy implements JsonSerializable
                         return $collection->put('middleware', $route->middleware());
                     })
                     ->filter()
-            );
-        });
-
-        return $allRoutes;
+            )
+        ));
     }
 
     /**

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -142,9 +142,12 @@ class Ziggy implements JsonSerializable
             $routes->put($name, $route);
         });
 
-        return $this->folioRoutes()->merge(
-            $routes->map(function ($route) use ($bindings) {
-                return collect($route)->only(['uri', 'methods', 'wheres'])
+        $allRoutes = $this->folioRoutes();
+
+        $routes->map(function ($route, $name) use ($bindings, $allRoutes) {
+            $allRoutes->put(
+                $name,
+                    collect($route)->only(['uri', 'methods', 'wheres'])
                     ->put('domain', $route->domain())
                     ->put('parameters', $route->parameterNames())
                     ->put('bindings', $bindings[$route->getName()] ?? [])
@@ -154,9 +157,12 @@ class Ziggy implements JsonSerializable
                         }
 
                         return $collection->put('middleware', $route->middleware());
-                    })->filter();
-            })
-        );
+                    })
+                    ->filter()
+            );
+        });
+
+        return $allRoutes;
     }
 
     /**

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -260,6 +260,14 @@ class Ziggy implements JsonSerializable
 
                         if ($field = $param->field()) {
                             $bindings[$name] = $field;
+                        } elseif ($param->bindable()) {
+                            $override = (new ReflectionClass($param->class()))->isInstantiable() && (
+                                (new ReflectionMethod($param->class(), 'getRouteKeyName'))->class !== Model::class
+                                || (new ReflectionMethod($param->class(), 'getKeyName'))->class !== Model::class
+                                || (new ReflectionProperty($param->class(), 'primaryKey'))->class !== Model::class
+                            );
+
+                            $bindings[$name] = $override ? app($param->class())->getRouteKeyName() : 'id';
                         }
                     }
                 }

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -254,7 +254,7 @@ class Ziggy implements JsonSerializable
                 if (Str::startsWith($segment, '[')) {
                     $param = new PotentiallyBindablePathSegment($segment);
 
-                    $parameters[] = $name = (string) Str::of($param->trimmed())->afterLast('.')->before(':')->before('-')->camel();
+                    $parameters[] = $name = $param->variable();
                     $segments[$i] = "{{$name}}";
 
                     if ($field = $param->field()) {
@@ -272,10 +272,11 @@ class Ziggy implements JsonSerializable
             }
 
             $uri = implode('/', $segments);
-            $uri = str_replace('/index', '', $uri);
+            $uri = Str::replaceEnd('/index', '', $uri);
 
             if ($route['domain'] && str_contains($route['domain'], '{')) {
-                array_unshift($parameters, Str::between($route['domain'], '{', '}'));
+                preg_match_all('/{(.*?)}/', $route['domain'], $matches);
+                array_unshift($parameters, ...$matches[1]);
             }
 
             $middleware = [];

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -52,13 +52,11 @@ class FolioTest extends TestCase
             'about' => [
                 'uri' => 'about',
                 'methods' => ['GET'],
-                'middleware' => ['web'],
             ],
             'users.show' => [
                 'uri' => 'users/{id}',
                 'methods' => ['GET'],
                 'parameters' => ['id'],
-                'middleware' => ['web'],
             ],
             'laravel-folio' => [
                 'uri' => '{fallbackPlaceholder}',
@@ -102,13 +100,11 @@ class FolioTest extends TestCase
             'uri' => 'users/{id}',
             'methods' => ['GET'],
             'parameters' => ['id'],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['users.show']);
         $this->assertSame([
             'uri' => 'users/{ids}',
             'methods' => ['GET'],
             'parameters' => ['ids'],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['users.some']);
     }
 
@@ -126,7 +122,6 @@ class FolioTest extends TestCase
                 'methods' => ['GET'],
                 'domain' => '{account}.ziggy.dev',
                 'parameters' => ['account', 'ids'],
-                'middleware' => ['web'],
             ],
         ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
     }
@@ -147,13 +142,11 @@ class FolioTest extends TestCase
                 'uri' => '{id}',
                 'methods' => ['GET'],
                 'parameters' => ['id'],
-                'middleware' => ['web'],
             ],
             'admins.some' => [
                 'uri' => 'admin/{ids}',
                 'methods' => ['GET'],
                 'parameters' => ['ids'],
-                'middleware' => ['web'],
             ],
         ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
     }
@@ -171,12 +164,10 @@ class FolioTest extends TestCase
             'blog.index' => [
                 'uri' => 'blog',
                 'methods' => ['GET'],
-                'middleware' => ['web'],
             ],
             'blog.categories.releases.index' => [
                 'uri' => 'blog/releases',
                 'methods' => ['GET'],
-                'middleware' => ['web'],
             ],
         ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
     }
@@ -191,6 +182,8 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages/admin'))
             ->uri('admin')
             ->middleware(['*' => ['auth']]);
+
+        config(['ziggy.middleware' => true]);
 
         $this->assertSame([
             'uri' => 'admin',
@@ -226,14 +219,12 @@ class FolioTest extends TestCase
                 'bindings' => [
                     'post' => 'slug',
                 ],
-                'middleware' => ['web'],
             ], (new Ziggy())->toArray()['routes']['posts.show']);
         }
         $this->assertSame([
             'uri' => 'users/{user}',
             'methods' => ['GET'],
             'parameters' => ['user'],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['users.show']);
         $this->assertSame([
             'uri' => 'teams/{team}',
@@ -242,7 +233,6 @@ class FolioTest extends TestCase
             'bindings' => [
                 'team' => 'uid',
             ],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['teams.show']);
     }
 
@@ -268,14 +258,12 @@ class FolioTest extends TestCase
                 'bindings' => [
                     'post' => 'slug',
                 ],
-                'middleware' => ['web'],
             ], (new Ziggy())->toArray()['routes']['posts.show']);
         }
         $this->assertSame([
             'uri' => 'users/{user}',
             'methods' => ['GET'],
             'parameters' => ['user'],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['users.show']);
         $this->assertSame([
             'uri' => 'teams/{team}',
@@ -284,7 +272,6 @@ class FolioTest extends TestCase
             'bindings' => [
                 'team' => 'uid',
             ],
-            'middleware' => ['web'],
         ], (new Ziggy())->toArray()['routes']['teams.show']);
     }
 
@@ -305,7 +292,6 @@ class FolioTest extends TestCase
             'bindings' => [
                 'folioUser' => 'uuid',
             ],
-            'middleware' => ['web'],
         ], (new Ziggy)->toArray()['routes']['users.show']);
         $this->assertSame([
             'uri' => 'tags/{folioTag}',
@@ -314,7 +300,6 @@ class FolioTest extends TestCase
             'bindings' => [
                 'folioTag' => 'id',
             ],
-            'middleware' => ['web'],
         ], (new Ziggy)->toArray()['routes']['tags.show']);
 
         $this->assertTrue(FolioUser::$wasBooted);

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -32,7 +32,7 @@ class FolioTest extends TestCase
     {
         return [
             ZiggyServiceProvider::class,
-            FolioServiceProvider::class,
+            ...((int) head(explode('.', app()->version())) >= 10 ? [FolioServiceProvider::class] : []),
         ];
     }
 
@@ -194,17 +194,15 @@ class FolioTest extends TestCase
             ->middleware(['*' => ['auth']]);
 
         $this->assertSame([
-            'admin.index' => [
-                'uri' => 'admin',
-                'methods' => ['GET'],
-                'middleware' => ['web', 'auth'],
-            ],
-            'admin.special' => [
-                'uri' => 'admin/special',
-                'methods' => ['GET'],
-                'middleware' => ['web', 'auth', 'special'],
-            ],
-        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
+            'uri' => 'admin',
+            'methods' => ['GET'],
+            'middleware' => ['web', 'auth'],
+        ], (new Ziggy())->toArray()['routes']['admin.index']);
+        $this->assertSame([
+            'uri' => 'admin/special',
+            'methods' => ['GET'],
+            'middleware' => ['web', 'auth', 'special'],
+        ], (new Ziggy())->toArray()['routes']['admin.special']);
     }
 
     /** @test */
@@ -220,30 +218,28 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'posts.show' => [
-                'uri' => 'posts/{post}',
-                'methods' => ['GET'],
-                'parameters' => ['post'],
-                'bindings' => [
-                    'post' => 'slug',
-                ],
-                'middleware' => ['web'],
+            'uri' => 'posts/{post}',
+            'methods' => ['GET'],
+            'parameters' => ['post'],
+            'bindings' => [
+                'post' => 'slug',
             ],
-            'users.show' => [
-                'uri' => 'users/{user}',
-                'methods' => ['GET'],
-                'parameters' => ['user'],
-                'middleware' => ['web'],
+            'middleware' => ['web'],
+        ], (new Ziggy())->toArray()['routes']['posts.show']);
+        $this->assertSame([
+            'uri' => 'users/{user}',
+            'methods' => ['GET'],
+            'parameters' => ['user'],
+            'middleware' => ['web'],
+        ], (new Ziggy())->toArray()['routes']['users.show']);
+        $this->assertSame([
+            'uri' => 'teams/{team}',
+            'methods' => ['GET'],
+            'parameters' => ['team'],
+            'bindings' => [
+                'team' => 'uid',
             ],
-            'teams.show' => [
-                'uri' => 'teams/{team}',
-                'methods' => ['GET'],
-                'parameters' => ['team'],
-                'bindings' => [
-                    'team' => 'uid',
-                ],
-                'middleware' => ['web'],
-            ],
-        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
+            'middleware' => ['web'],
+        ], (new Ziggy())->toArray()['routes']['teams.show']);
     }
 }

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -98,19 +98,17 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'users.show' => [
-                'uri' => 'users/{id}',
-                'methods' => ['GET'],
-                'parameters' => ['id'],
-                'middleware' => ['web'],
-            ],
-            'users.some' => [
-                'uri' => 'users/{ids}',
-                'methods' => ['GET'],
-                'parameters' => ['ids'],
-                'middleware' => ['web'],
-            ],
-        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
+            'uri' => 'users/{id}',
+            'methods' => ['GET'],
+            'parameters' => ['id'],
+            'middleware' => ['web'],
+        ], (new Ziggy())->toArray()['routes']['users.show']);
+        $this->assertSame([
+            'uri' => 'users/{ids}',
+            'methods' => ['GET'],
+            'parameters' => ['ids'],
+            'middleware' => ['web'],
+        ], (new Ziggy())->toArray()['routes']['users.some']);
     }
 
     /** @test */
@@ -210,22 +208,26 @@ class FolioTest extends TestCase
     {
         File::ensureDirectoryExists(resource_path('views/pages/users'));
         File::put(resource_path('views/pages/users/[User].blade.php'), '<?php Laravel\Folio\name("users.show");');
-        File::ensureDirectoryExists(resource_path('views/pages/posts'));
-        File::put(resource_path('views/pages/posts/[Post:slug].blade.php'), '<?php Laravel\Folio\name("posts.show");');
+        if (! str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            File::ensureDirectoryExists(resource_path('views/pages/posts'));
+            File::put(resource_path('views/pages/posts/[Post:slug].blade.php'), '<?php Laravel\Folio\name("posts.show");');
+        }
         File::ensureDirectoryExists(resource_path('views/pages/teams'));
         File::put(resource_path('views/pages/teams/[Team-uid].blade.php'), '<?php Laravel\Folio\name("teams.show");');
 
         Folio::path(resource_path('views/pages'));
 
-        $this->assertSame([
-            'uri' => 'posts/{post}',
-            'methods' => ['GET'],
-            'parameters' => ['post'],
-            'bindings' => [
-                'post' => 'slug',
-            ],
-            'middleware' => ['web'],
-        ], (new Ziggy())->toArray()['routes']['posts.show']);
+        if (! str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            $this->assertSame([
+                'uri' => 'posts/{post}',
+                'methods' => ['GET'],
+                'parameters' => ['post'],
+                'bindings' => [
+                    'post' => 'slug',
+                ],
+                'middleware' => ['web'],
+            ], (new Ziggy())->toArray()['routes']['posts.show']);
+        }
         $this->assertSame([
             'uri' => 'users/{user}',
             'methods' => ['GET'],

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -12,6 +12,15 @@ use Tighten\Ziggy\ZiggyServiceProvider;
 
 class FolioTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ((int) head(explode('.', app()->version())) < 10) {
+            $this->markTestSkipped('Folio requires Laravel >=10');
+        }
+    }
+
     protected function tearDown(): void
     {
         File::deleteDirectories(resource_path('views'));

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Laravel\Folio\Folio;
+use Laravel\Folio\FolioRoutes;
+use Laravel\Folio\FolioServiceProvider;
+use Tests\TestCase;
+use Tighten\Ziggy\Ziggy;
+use Tighten\Ziggy\ZiggyServiceProvider;
+
+class FolioTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $router = app('router');
+
+        $router->get('home', $this->noop())->name('home');
+        $router->get('posts', $this->noop())->name('posts.index');
+
+        $router->getRoutes()->refreshNameLookups();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectories(resource_path('views'));
+
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ZiggyServiceProvider::class,
+            FolioServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function include_folio_routes()
+    {
+        // middleware!
+        // route model binding
+        // wheres?
+        File::ensureDirectoryExists(resource_path('views/pages'));
+        File::put(resource_path('views/pages/about.blade.php'), '<?php Laravel\Folio\name("about");');
+        File::put(resource_path('views/pages/anonymous.blade.php'), '<?php');
+        File::ensureDirectoryExists(resource_path('views/pages/users'));
+        File::put(resource_path('views/pages/users/[id].blade.php'), '<?php Laravel\Folio\name("users.show");');
+        Folio::path(resource_path('views/pages'));
+
+        dump(app(FolioRoutes::class)->routes());
+
+        $this->assertSame([
+            'about' => [
+                // 'uri' => 'about',
+                'methods' => ['GET'],
+            ],
+            'users.show' => [
+                // 'uri' => 'users/{id}',
+                'methods' => ['GET'],
+                // 'parameters' => ['id'],
+            ],
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'laravel-folio' => [
+                'uri' => '{fallbackPlaceholder}',
+                'methods' => ['GET', 'HEAD'],
+                'wheres' => ['fallbackPlaceholder' => '.*'],
+                'parameters' => ['fallbackPlaceholder'],
+            ],
+        ], (new Ziggy())->toArray()['routes']);
+    }
+}

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -382,33 +382,33 @@ class FolioTest extends TestCase
     /** @test */
     public function model_bindings_with_both_custom_field_and_custom_variable()
     {
-        File::ensureDirectoryExists(resource_path('views/pages/users'));
-        File::put(resource_path('views/pages/users/[.Tests.Unit.FolioUser:email|user].blade.php'), '<?php Laravel\Folio\name("users.show");');
         if (! windows_os()) {
-            File::ensureDirectoryExists(resource_path('views/pages/tags'));
-            File::put(resource_path('views/pages/tags/[.Tests.Unit.FolioTag-slug-$tag].blade.php'), '<?php Laravel\Folio\name("tags.show");');
+            File::ensureDirectoryExists(resource_path('views/pages/users'));
+            File::put(resource_path('views/pages/users/[.Tests.Unit.FolioUser:email|user].blade.php'), '<?php Laravel\Folio\name("users.show");');
         }
+        File::ensureDirectoryExists(resource_path('views/pages/tags'));
+        File::put(resource_path('views/pages/tags/[.Tests.Unit.FolioTag-slug-$tag].blade.php'), '<?php Laravel\Folio\name("tags.show");');
 
         Folio::path(resource_path('views/pages'));
 
-        $this->assertSame([
-            'uri' => 'users/{user}',
-            'methods' => ['GET'],
-            'parameters' => ['user'],
-            'bindings' => [
-                'user' => 'email',
-            ],
-        ], (new Ziggy)->toArray()['routes']['users.show']);
         if (! windows_os()) {
             $this->assertSame([
-                'uri' => 'tags/{tag}',
+                'uri' => 'users/{user}',
                 'methods' => ['GET'],
-                'parameters' => ['tag'],
+                'parameters' => ['user'],
                 'bindings' => [
-                    'tag' => 'slug',
+                    'user' => 'email',
                 ],
-            ], (new Ziggy)->toArray()['routes']['tags.show']);
+            ], (new Ziggy)->toArray()['routes']['users.show']);
         }
+        $this->assertSame([
+            'uri' => 'tags/{tag}',
+            'methods' => ['GET'],
+            'parameters' => ['tag'],
+            'bindings' => [
+                'tag' => 'slug',
+            ],
+        ], (new Ziggy)->toArray()['routes']['tags.show']);
     }
 }
 

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -292,37 +292,37 @@ class FolioTest extends TestCase
     public function implicit_route_model_bindings()
     {
         File::ensureDirectoryExists(resource_path('views/pages/users'));
-        File::put(resource_path('views/pages/users/[.Tests.Unit.User].blade.php'), '<?php Laravel\Folio\name("users.show");');
+        File::put(resource_path('views/pages/users/[.Tests.Unit.FolioUser].blade.php'), '<?php Laravel\Folio\name("users.show");');
         File::ensureDirectoryExists(resource_path('views/pages/tags'));
-        File::put(resource_path('views/pages/tags/[.Tests.Unit.Tag].blade.php'), '<?php Laravel\Folio\name("tags.show");');
+        File::put(resource_path('views/pages/tags/[.Tests.Unit.FolioTag].blade.php'), '<?php Laravel\Folio\name("tags.show");');
 
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'uri' => 'users/{user}',
+            'uri' => 'users/{folioUser}',
             'methods' => ['GET'],
-            'parameters' => ['user'],
+            'parameters' => ['folioUser'],
             'bindings' => [
-                'user' => 'uuid',
+                'folioUser' => 'uuid',
             ],
             'middleware' => ['web'],
         ], (new Ziggy)->toArray()['routes']['users.show']);
         $this->assertSame([
-            'uri' => 'tags/{tag}',
+            'uri' => 'tags/{folioTag}',
             'methods' => ['GET'],
-            'parameters' => ['tag'],
+            'parameters' => ['folioTag'],
             'bindings' => [
-                'tag' => 'id',
+                'folioTag' => 'id',
             ],
             'middleware' => ['web'],
         ], (new Ziggy)->toArray()['routes']['tags.show']);
 
-        $this->assertTrue(User::$wasBooted);
-        $this->assertFalse(Tag::$wasBooted);
+        $this->assertTrue(FolioUser::$wasBooted);
+        $this->assertFalse(FolioTag::$wasBooted);
     }
 }
 
-class User extends Model
+class FolioUser extends Model
 {
     public static $wasBooted = false;
 
@@ -338,7 +338,7 @@ class User extends Model
     }
 }
 
-class Tag extends Model
+class FolioTag extends Model
 {
     public static $wasBooted = false;
 

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -38,7 +38,7 @@ class FolioTest extends TestCase
     }
 
     /** @test */
-    public function include_folio_routes()
+    public function include_named_folio_routes()
     {
         File::ensureDirectoryExists(resource_path('views/pages'));
         File::put(resource_path('views/pages/about.blade.php'), '<?php Laravel\Folio\name("about");');
@@ -161,15 +161,13 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'root' => [
-                'uri' => '/',
-                'methods' => ['GET'],
-            ],
-            'index.index' => [
-                'uri' => 'index/index',
-                'methods' => ['GET'],
-            ],
-        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
+            'uri' => '/',
+            'methods' => ['GET'],
+        ], (new Ziggy())->toArray()['routes']['root']);
+        $this->assertSame([
+            'uri' => 'index/index',
+            'methods' => ['GET'],
+        ], (new Ziggy())->toArray()['routes']['index.index']);
     }
 
     /** @test */

--- a/tests/Unit/FolioTest.php
+++ b/tests/Unit/FolioTest.php
@@ -71,10 +71,12 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'uri' => 'about',
-            // Folio routes only respond to 'GET', so this is the web route
-            'methods' => ['GET', 'HEAD'],
-        ], (new Ziggy())->toArray()['routes']['about']);
+            'about' => [
+                'uri' => 'about',
+                // Folio routes only respond to 'GET', so this is the web route
+                'methods' => ['GET', 'HEAD'],
+            ],
+        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
     }
 
     /** @test */
@@ -87,18 +89,19 @@ class FolioTest extends TestCase
         Folio::path(resource_path('views/pages'));
 
         $this->assertSame([
-            'uri' => 'users/{id}',
-            'methods' => ['GET'],
-            'parameters' => ['id'],
-            'middleware' => ['web'],
-        ], (new Ziggy())->toArray()['routes']['users.show']);
-
-        $this->assertSame([
-            'uri' => 'users/{ids}',
-            'methods' => ['GET'],
-            'parameters' => ['ids'],
-            'middleware' => ['web'],
-        ], (new Ziggy())->toArray()['routes']['users.some']);
+            'users.show' => [
+                'uri' => 'users/{id}',
+                'methods' => ['GET'],
+                'parameters' => ['id'],
+                'middleware' => ['web'],
+            ],
+            'users.some' => [
+                'uri' => 'users/{ids}',
+                'methods' => ['GET'],
+                'parameters' => ['ids'],
+                'middleware' => ['web'],
+            ],
+        ], Arr::except((new Ziggy())->toArray()['routes'], 'laravel-folio'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds support for [Laravel Folio](https://laravel.com/docs/folio). Closes #732.

Laravel Folio registers its routes _very_ differently from how Laravel usually handles routes, so unfortunately this is a bit messy. We're more or less doing what Folio's [`ListCommand`](https://github.com/laravel/folio/blob/master/src/Console/ListCommand.php) is doing, modified for our needs.

Notes:

- We only deal with named Folio routes.
- Folio includes the (undocumented) ability to specify a custom view data variable name for a route parameter (e.g. https://github.com/laravel/folio/blob/master/tests/Unit/ModelBindingTest.php#L114). Ziggy will use these custom view data variable names as the route parameter names if they're present, because this is what Folio does internally and we would have to anyway so that we avoid duplicate parameter names.