### PR TITLE
Fix Vue plugin on Vue 2

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,10 +11,15 @@ export const ZiggyVue = {
         const r = (name, params, absolute, config = options) =>
             route(name, params, absolute, config);
 
-        app.config.globalProperties.route = r;
-
         if (parseInt(app.version) > 2) {
+            app.config.globalProperties.route = r;
             app.provide('route', r);
+        } else {
+            app.mixin({
+                methods: {
+                    route: r,
+                },
+            });
         }
     },
 };


### PR DESCRIPTION
This PR fixes the Vue plugin to work with Vue 2. Closes #737.

Not sure how the underlying changes slipped in, but they weren't supposed to.

- Only registers `app.config.globalProperties.route` in Vue 3. This was discussed and removed in #518, in Vue 3 it's the preferred way to register things globally.
- Restores the Vue 2 mixin to make `route` available everywhere. Removing this eventually was also discussed in #518, but for Vue 2 users that would just be annoying.

This PR makes one small change from the _intended_ previous behavior—in Vue 3, we now register a global `route` property instead of adding a mixin.