### PR TITLE
fix route().params type

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -157,7 +157,7 @@ interface Config {
 interface Router {
     current(): RouteName | undefined;
     current<T extends RouteName>(name: T, params?: ParameterValue | RouteParams<T>): boolean;
-    get params(): Record<string, unknown>;
+    get params(): Record<string, string>;
     has<T extends RouteName>(name: T): boolean;
 }
 


### PR DESCRIPTION
As mentioned in docs route().params will always return the params as string value