### PR TITLE
Ziggy Import Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Ziggy includes a Vue plugin to make it easy to use the `route()` helper througho
 
 ```js
 import { createApp } from 'vue';
-import { ZiggyVue } from 'ziggy-js';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 import App from './App.vue';
 
 createApp(App).use(ZiggyVue);


### PR DESCRIPTION
Maybe I am missing a step? This is the only way I can get the import to work without getting an error from vite.

Laravel 10 and 11.
"tightenco/ziggy": "^2.1"

Hope this helps?