### PR TITLE
Fix parameter validation when generating relative URLs to routes with domain parameters

### DIFF
--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -791,6 +791,26 @@ describe('route()', () => {
         expect(route('catalog-domain-param-path', ['/p/test'], false)).toBe('/catalog//p/test');
     });
 
+    // Highest potential for "breaking" changes when fixing these is the second format in each example, where
+    // params are passed as an array, because it's less clear in that case which param is which since we're
+    // relying on the order they're passed. It may break some people's code but it's probably more
+    // important to match Laravel's behaviour correctly, this is a pretty big inconsistency.
+    test('handle domain parameters when generating relative URL', () => {
+        // Just for demonstration purposes, this is tested properly elsewhere
+        expect(route('team.user.show', { team: 1, id: 2 })).toBe('https://1.ziggy.dev/users/2');
+        expect(route('team.user.show', [1, 2])).toBe('https://1.ziggy.dev/users/2');
+
+        // Laravel route() errors here, domain {team} param is required
+        // We should *probably* match that behaviour and error too
+        expect(route('team.user.show', { id: 2 }, false)).toBe('/users/2');
+        expect(route('team.user.show', [2], false)).toBe('/users/2');
+
+        // Laravel route() handles these find, {team} param is recognized even though final output won't contain it
+        // We should *definitely* match that behaviour and handle these properly
+        expect(route('team.user.show', { team: 1, id: 2 }, false)).toBe('/users/2');
+        expect(route('team.user.show', [1, 2], false)).toBe('/users/2');
+    });
+
     test('skip encoding some characters in route parameters', () => {
         // Laravel doesn't encode these characters in route parameters: / @ : ; , = + ! * | ? & # %
         expect(route('pages', 'a/b')).toBe('https://ziggy.dev/a/b');


### PR DESCRIPTION
Laravel **requires** that domain parameters always be passed to the `route()` helper, even if the user is generating a relative URL and the domain parameters will not appear in the final output. Omitting the parameter results in an error. Depending how the parameters are passed the error will be different, but the underlying problem is the same:

```php
Route::domain('{team}.ziggy.dev')->get('users/{user}', fn () => '')->name('users.index');

// Desired output: "/users/1"

route('users.index', ['team' => 'tighten', 'user' => 1], absolute: false);
// Produces desired output

route('users.index', ['user' => 1], absolute: false);
// Error, missing required route parameter 'team' - only one param value was passed, and it was specifically assigned to the `user` param

route('users.index', ['tighten', 1], absolute: false);
// Produces desired output

route('users.index', [1], absolute: false);
// Error, missing required route parameter 'user' - because param values were passed in order, `1` was handled as the `team` parameter
```

Ziggy currently behaves exactly the opposite way—it effectively **prohibits** domain parameters from being passed to the `route()` helper and handled as such, if the user is generating a relative URL:

```js
// Desired output: "/users/1"

route('users.index', { user: 1 }, false);
// Produces desired output, unlike Laravel, which errors in this case

route('users.index', { team: 'tighten', user: 1 }, false);
// Produces "/users/1?team=tighten", incorrectly adding the `tighten` domain parameter to the query

route('users.index', [1], false);
// Produces desired output, unlike Laravel, which errors

route('users.index', ['tighten', 1], false);
// Produces "/users/tighten?1", incorrectly handling `'tighten'` as the `user` parameter and adding `1` to the query
```

So Laravel requires that _all_ required parameters be provided, and Ziggy requires that _only the required parameters that will appear in the output_ be provided.

This was almost certainly unintentional, and a side effect of how we replace parameters in the URL. Ziggy generates a template of the **final output** of the `route()` helper, which, if the `relative` option was passed, only contains the route path, and then replaces all the parameters in that template. Laravel generates a template of the **entire URL**, replaces all the parameters in that template, and then returns only the path if the relative option was passed.

I'm going to propose that we update Ziggy to match Laravel's behaviour, which is a large change, but justified in my opinion since it fixes what I believe is a large bug.

For now this PR includes a failing test demonstrating the issue.