### PR TITLE
Laravel route change

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ If you need to retrieve Ziggy's config from your Laravel backend over the networ
 
 use Tighten\Ziggy\Ziggy;
 
-Route::get('api/ziggy', fn () => response()->json(new Ziggy));
+Route::get('ziggy', fn () => response()->json(new Ziggy));
 ```
 
 ### Re-generating the routes file when your app routes change


### PR DESCRIPTION
We already mention in the comment line: "// routes/api.php".

if we are say 
"Route::get('api/ziggy', fn () => response()->json(new Ziggy));"

this time laravel will create like this route:

"api/api/ziggy"