### PR TITLE
Escape special regex characters when matching routes

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -80,6 +80,7 @@ export default class Route {
         // Transform the route's template into a regex that will match a hydrated URL,
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
+            .replace(/[.*+^$()|[\]]/g, '\\$&')
             .replace(/(\/?){([^}?]*)(\??)}/g, (_, slash, segment, optional) => {
                 const regex = `(?<${segment}>${
                     this.wheres[segment]?.replace(/(^\^)|(\$$)/g, '') || '[^/?]+'

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -80,7 +80,7 @@ export default class Route {
         // Transform the route's template into a regex that will match a hydrated URL,
         // by replacing its parameter segments with matchers for parameter values
         const pattern = this.template
-            .replace(/[.*+^$()|[\]]/g, '\\$&')
+            .replace(/[.*+$()[\]]/g, '\\$&')
             .replace(/(\/?){([^}?]*)(\??)}/g, (_, slash, segment, optional) => {
                 const regex = `(?<${segment}>${
                     this.wheres[segment]?.replace(/(^\^)|(\$$)/g, '') || '[^/?]+'

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -262,7 +262,7 @@ const defaultZiggy = {
             parameters: ['storefront', 'catalog_uri'],
         },
         regexSpecialChars: {
-            uri: 'test.*+^$()|[]/{slug}',
+            uri: 'test.*+$()[]/{slug}',
             methods: ['GET', 'HEAD'],
         },
     },
@@ -1444,7 +1444,7 @@ describe('current()', () => {
     });
 
     test('matches route with escaped Regex special characters', () => {
-        global.window.location.pathname = '/test.*+^$()|[]/1';
+        global.window.location.pathname = '/test.*+$()[]/1';
 
         expect(route().current()).toBe('regexSpecialChars');
         expect(route().current('regexSpecialChars')).toBe(true);

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -261,6 +261,10 @@ const defaultZiggy = {
             },
             parameters: ['storefront', 'catalog_uri'],
         },
+        regexSpecialChars: {
+            uri: 'test.*+^$()|[]/{slug}',
+            methods: ['GET', 'HEAD'],
+        },
     },
 };
 
@@ -1437,6 +1441,13 @@ describe('current()', () => {
 
         expect(route().current('events.venues-index')).toBe(true);
         expect(route().current('events.venues.*')).toBe(false);
+    });
+
+    test('matches route with escaped Regex special characters', () => {
+        global.window.location.pathname = '/test.*+^$()|[]/1';
+
+        expect(route().current()).toBe('regexSpecialChars');
+        expect(route().current('regexSpecialChars')).toBe(true);
     });
 
     test.skip('can unresolve arbitrary urls to names and params', () => {


### PR DESCRIPTION
I noticed routes with dots inside (e.g. `{post}.{slug}`) does not match using `route().current()`. Indeed RegEx special characters are currently not escaped, so I added a remplacement for :
```
.*+^$()|[]
```
I excluded `{}?` chars because there are needed for parameters.