### PR TITLE
Fix params sometimes being double-decoded

### DIFF
--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -91,7 +91,9 @@ export default class Route {
 
         const [location, query] = url.replace(/^\w+:\/\//, '').split('?');
 
-        const matches = new RegExp(`^${pattern}/?$`).exec(decodeURI(location));
+        const matches =
+            new RegExp(`^${pattern}/?$`).exec(location) ??
+            new RegExp(`^${pattern}/?$`).exec(decodeURI(location));
 
         if (matches) {
             for (const k in matches.groups) {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1412,6 +1412,13 @@ describe('current()', () => {
         expect(route().current('statistics')).toBe(true);
     });
 
+    test('can check the current route with encoded percent sign', () => {
+        global.window.location.pathname = '/optionalpage/john%25';
+
+        expect(route().current()).toBe('pages.optional');
+        expect(route().current('pages.optional')).toBe(true);
+    });
+
     test('can ignore routes that don’t allow GET requests', () => {
         global.window.location.pathname = '/posts/1';
 


### PR DESCRIPTION
Calling `decodeURI` before we try to match params allows us to handle Cyrillic characters, but it decodes other characters too, which means `decodeURIComponent` a few lines later tries to decode them again. I think this actually doesn't matter for most characters, but `%` specifically causes problems because it can't be decoded again on its own.

I'm not positive that this solution works perfectly, if it causes other issues I might tweak how we support Cyrillic characters. Cyrillic characters are only decoded for _display_, in `location.href` and other JavaScript stuff they're kept encoded so we might need to do that too.

Fixes #777.