### PR TITLE
Add ability to strictly type check route names

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -6,6 +6,11 @@
 export interface RouteList {}
 
 /**
+ * Marker interface to configure Ziggy's type checking behavior.
+ */
+export interface TypeConfig {}
+
+/**
  * A route name registered with Ziggy.
  */
 type KnownRouteName = keyof RouteList;
@@ -13,7 +18,9 @@ type KnownRouteName = keyof RouteList;
 /**
  * A route name, or any string.
  */
-type RouteName = KnownRouteName | (string & {});
+type RouteName = TypeConfig extends { strictRouteNames: true }
+    ? KnownRouteName
+    : KnownRouteName | (string & {});
 // `(string & {})` prevents TypeScript from reducing this type to just `string`,
 // which would prevent intellisense from autocompleting known route names.
 // See https://stackoverflow.com/a/61048124/6484459.

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -102,3 +102,10 @@ assertType(route().current('posts.comments.show', 'foo'));
 assertType<string>(route('optional', { maybe: 'foo' }));
 assertType<string>(route('optional', 'foo'));
 assertType<Router>(route(undefined, undefined, undefined, {} as Config));
+
+// Uncomment to test strict route name checking - invalid route names in this file should error
+// declare module '../../src/js' {
+//     interface TypeConfig {
+//         strictRouteNames: true;
+//     }
+// }


### PR DESCRIPTION
This PR adds the ability for Ziggy to display type errors when passed route names that aren't present in the route list:

```ts
declare module 'ziggy-js' {
    interface RouteList {
        'home': [];
    }
    // New in this PR
    interface TypeConfig {
        strictRouteNames: true;
    }
}

route('hom'); // TypeError because there's no route called "hom"
```

As seen above, this functionality can be enabled by overriding the new `TypeConfig` interface and setting a `strictRouteNames` property on it to `true`.

This is optional and not enabled by default, although in the future we may want to consider whether this would be preferable as Ziggy's default behavior out of the box.

Thanks to @Andyuu for this solution! See https://github.com/tighten/ziggy/discussions/759#discussioncomment-10916385.