### PR TITLE
Only limit route names when calling route()

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -26,11 +26,9 @@ type RouteName = KnownRouteName | (string & {});
 // See https://stackoverflow.com/a/61048124/6484459.
 
 /**
- * Valid route names to pass to route().
+ * A valid route name to pass to `route()` to generate a URL.
  */
-type AllowedRouteName = TypeConfig extends { strictRouteNames: true }
-    ? KnownRouteName
-    : RouteName;
+type ValidRouteName = TypeConfig extends { strictRouteNames: true } ? KnownRouteName : RouteName;
 
 /**
  * Information about a single route parameter.
@@ -192,14 +190,14 @@ export function route(
 ): Router;
 
 // Called with a route name and optional additional arguments - returns a URL string
-export function route<T extends AllowedRouteName>(
+export function route<T extends ValidRouteName>(
     name: T,
     params?: RouteParams<T> | undefined,
     absolute?: boolean,
     config?: Config,
 ): string;
 
-export function route<T extends AllowedRouteName>(
+export function route<T extends ValidRouteName>(
     name: T,
     params?: ParameterValue | undefined,
     absolute?: boolean,

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -20,12 +20,17 @@ type KnownRouteName = keyof RouteList;
 /**
  * A route name, or any string.
  */
-type RouteName = TypeConfig extends { strictRouteNames: true }
-    ? KnownRouteName
-    : KnownRouteName | (string & {});
+type RouteName = KnownRouteName | (string & {});
 // `(string & {})` prevents TypeScript from reducing this type to just `string`,
 // which would prevent intellisense from autocompleting known route names.
 // See https://stackoverflow.com/a/61048124/6484459.
+
+/**
+ * Valid route names to pass to route().
+ */
+type AllowedRouteName = TypeConfig extends { strictRouteNames: true }
+    ? KnownRouteName
+    : RouteName;
 
 /**
  * Information about a single route parameter.
@@ -187,14 +192,14 @@ export function route(
 ): Router;
 
 // Called with a route name and optional additional arguments - returns a URL string
-export function route<T extends RouteName>(
+export function route<T extends AllowedRouteName>(
     name: T,
     params?: RouteParams<T> | undefined,
     absolute?: boolean,
     config?: Config,
 ): string;
 
-export function route<T extends RouteName>(
+export function route<T extends AllowedRouteName>(
     name: T,
     params?: ParameterValue | undefined,
     absolute?: boolean,


### PR DESCRIPTION
When `strictRouteNames` is set, we still need to allow wildcard route names to be passed to `current()` and potentially invalid route names to be passed to `has()`.

This changes allows `route().current('dashboard.*')` to be considered valid while still preventing calling `route()` with an unknown route name.