### PR TITLE
Add some type hinting to fix a warning about implicitly marking param

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -9,7 +9,7 @@ class BladeRouteGenerator
 {
     public static $generated;
 
-    public function generate($group = null, ?string $nonce = null): string
+    public function generate(?array $group = null, ?string $nonce = null): string
     {
         $ziggy = new Ziggy($group);
 
@@ -28,10 +28,10 @@ class BladeRouteGenerator
         return (string) new $output($ziggy, $routeFunction, $nonce);
     }
 
-    private function generateMergeJavascript(Ziggy $ziggy, string $nonce)
+    private function generateMergeJavascript(Ziggy $ziggy, string $nonce): string
     {
         $output = config('ziggy.output.merge_script', MergeScript::class);
-
+dd($output);
         return new $output($ziggy, $nonce);
     }
 }

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -31,7 +31,7 @@ class BladeRouteGenerator
     private function generateMergeJavascript(Ziggy $ziggy, string $nonce): string
     {
         $output = config('ziggy.output.merge_script', MergeScript::class);
-dd($output);
+
         return new $output($ziggy, $nonce);
     }
 }


### PR DESCRIPTION
Spotted this warning on my dev console, so I've tweaked the type handling a little bit.

│ Tighten\Ziggy\BladeRouteGenerator::generate(): Implicitly marking parameter... │