### PR TITLE
feat: support passing except/only args to ziggy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Route::get('ziggy', fn () => response()->json(new Ziggy));
 
 ### Re-generating the routes file when your app routes change
 
-If you are generating your Ziggy config as a file by running `php artisan ziggy:generate`, you may want to re-run that command when your app's route files change. The example below is a Laravel Mix plugin, but similar functionality could be achieved without Mix. Huge thanks to [Nuno Rodrigues](https://github.com/nacr) for [the idea and a sample implementation](https://github.com/tighten/ziggy/issues/321#issuecomment-689150082). See [vite-plugin-ziggy](https://github.com/aniftyco/vite-plugin-ziggy) for how to use it with Vite.
+If you are generating your Ziggy config as a file by running `php artisan ziggy:generate`, you may want to re-run that command when your app's route files change. The example below is a Laravel Mix plugin, but similar functionality could be achieved without Mix. Huge thanks to [Nuno Rodrigues](https://github.com/nacr) for [the idea and a sample implementation](https://github.com/tighten/ziggy/issues/321#issuecomment-689150082). See [#655](https://github.com/tighten/ziggy/pull/655/files#diff-4aeb78f813e14842fcf95bdace9ced23b8a6eed60b23c165eaa52e8db2f97b61) or [vite-plugin-ziggy](https://github.com/aniftyco/vite-plugin-ziggy) for Vite examples.
 
 <details>
 <summary>Laravel Mix plugin example</summary>

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Route::get('ziggy', fn () => response()->json(new Ziggy));
 
 ### Re-generating the routes file when your app routes change
 
-If you are generating your Ziggy config as a file by running `php artisan ziggy:generate`, you may want to re-run that command when your app's route files change. The example below is a Laravel Mix plugin, but similar functionality could be achieved without Mix. Huge thanks to [Nuno Rodrigues](https://github.com/nacr) for [the idea and a sample implementation](https://github.com/tighten/ziggy/issues/321#issuecomment-689150082). See [#655 for a Vite example](https://github.com/tighten/ziggy/pull/655/files#diff-4aeb78f813e14842fcf95bdace9ced23b8a6eed60b23c165eaa52e8db2f97b61).
+If you are generating your Ziggy config as a file by running `php artisan ziggy:generate`, you may want to re-run that command when your app's route files change. The example below is a Laravel Mix plugin, but similar functionality could be achieved without Mix. Huge thanks to [Nuno Rodrigues](https://github.com/nacr) for [the idea and a sample implementation](https://github.com/tighten/ziggy/issues/321#issuecomment-689150082). See [vite-plugin-ziggy](https://github.com/aniftyco/vite-plugin-ziggy) for how to use it with Vite.
 
 <details>
 <summary>Laravel Mix plugin example</summary>

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Tighten\Ziggy\Output\File;
 use Tighten\Ziggy\Output\Types;
-use Tighten\Ziggy\Ziggy;
 
 class CommandRouteGenerator extends Command
 {
@@ -15,13 +14,20 @@ class CommandRouteGenerator extends Command
                             {--types : Generate a TypeScript declaration file.}
                             {--types-only : Generate only a TypeScript declaration file.}
                             {--url=}
-                            {--group=}';
+                            {--group=}
+                            {--except=}
+                            {--only=}';
 
     protected $description = 'Generate a JavaScript file containing Ziggy’s routes and configuration.';
 
     public function handle(Filesystem $filesystem)
     {
-        $ziggy = new Ziggy($this->option('group'), $this->option('url') ? url($this->option('url')) : null);
+        $ziggy = new Ziggy(
+            $this->option('group'),
+            $this->option('url') ? url($this->option('url')) : null,
+            $this->option('except') ? explode(',', $this->option('except')) : null,
+            $this->option('only') ? explode(',', $this->option('only')) : null,
+        );
 
         $path = $this->argument('path') ?? config('ziggy.output.path', 'resources/js/ziggy.js');
 

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -15,8 +15,8 @@ class CommandRouteGenerator extends Command
                             {--types-only : Generate only a TypeScript declaration file.}
                             {--url=}
                             {--group=}
-                            {--except=}
-                            {--only=}';
+                            {--except= : Comma delimited list of route names to exclude.}
+                            {--only= : Comma delimited list of route names to include.}';
 
     protected $description = 'Generate a JavaScript file containing Ziggy’s routes and configuration.';
 

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Tighten\Ziggy\Output\File;
 use Tighten\Ziggy\Output\Types;
+use Tighten\Ziggy\Ziggy;
 
 class CommandRouteGenerator extends Command
 {
@@ -15,8 +16,8 @@ class CommandRouteGenerator extends Command
                             {--types-only : Generate only a TypeScript declaration file.}
                             {--url=}
                             {--group=}
-                            {--except= : Comma delimited list of route names to exclude.}
-                            {--only= : Comma delimited list of route names to include.}';
+                            {--except= : Route name patterns to exclude.}
+                            {--only= : Route name patterns to include.}';
 
     protected $description = 'Generate a JavaScript file containing Ziggy’s routes and configuration.';
 

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -22,12 +22,13 @@ class CommandRouteGenerator extends Command
 
     public function handle(Filesystem $filesystem)
     {
-        $ziggy = new Ziggy(
-            $this->option('group'),
-            $this->option('url') ? url($this->option('url')) : null,
-            $this->option('except') ? explode(',', $this->option('except')) : null,
-            $this->option('only') ? explode(',', $this->option('only')) : null,
-        );
+        $ziggy = new Ziggy($this->option('group'), $this->option('url') ? url($this->option('url')) : null);
+
+        if ($this->option('except') && ! $this->option('only')) {
+            $ziggy->filter(explode(',', $this->option('except')), false);
+        } else if ($this->option('only') && ! $this->option('except')) {
+            $ziggy->filter(explode(',', $this->option('only')));
+        }
 
         $path = $this->argument('path') ?? config('ziggy.output.path', 'resources/js/ziggy.js');
 

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -26,12 +26,8 @@ class Ziggy implements JsonSerializable
     public function __construct(
         protected $group = null,
         protected ?string $url = null,
-        protected ?array $except = null,
-        protected ?array $only = null
     ) {
         $this->url = rtrim($url ?? url('/'), '/');
-        $this->except = $except ?? config('ziggy.except', []);
-        $this->only = $only ?? config('ziggy.only', []);
 
         $this->routes = static::$cache ??= $this->nameKeyedRoutes();
     }
@@ -47,12 +43,12 @@ class Ziggy implements JsonSerializable
             return $this->group($group);
         }
 
-        if (count($this->except) > 0 && count($this->only) === 0) {
-            return $this->filter($this->except, false)->routes;
+        if (config()->has('ziggy.except') && ! config()->has('ziggy.only')) {
+            return $this->filter(config('ziggy.except'), false)->routes;
         }
 
-        if (count($this->only) > 0 && count($this->except) === 0) {
-            return $this->filter($this->only)->routes;
+        if (config()->has('ziggy.only') && ! config()->has('ziggy.except')) {
+            return $this->filter(config('ziggy.only'))->routes;
         }
 
         return $this->routes;
@@ -208,7 +204,7 @@ class Ziggy implements JsonSerializable
 
         // Use existing named Folio routes (instead of searching view files) to respect route caching
         return collect(app(FolioRoutes::class)->routes())->map(function (array $route) {
-            $uri = rtrim($route['baseUri'], '/').str_replace([$route['mountPath'], '.blade.php'], '', $route['path']);
+            $uri = rtrim($route['baseUri'], '/') . str_replace([$route['mountPath'], '.blade.php'], '', $route['path']);
 
             $segments = explode('/', $uri);
             $parameters = [];

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -66,13 +66,33 @@ test('generate file respecting config', function () {
     expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
 });
 
-test('generate file respecting exclude options', function () {
+test('generate file using --except option', function () {
     Route::get('posts/{post}/comments', fn () => '')->name('postComments.index');
     Route::get('slashes/{slug}', fn () => '')->where('slug', '.*')->name('slashes');
     Route::get('admin', fn () => '')->name('admin.dashboard'); // Excluded by options
 
     artisan('ziggy:generate --except=admin.*');
 
+    expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
+});
+
+test('generate file using --only option', function () {
+    Route::get('posts/{post}/comments', fn () => '')->name('postComments.index');
+    Route::get('slashes/{slug}', fn () => '')->where('slug', '.*')->name('slashes');
+    Route::get('admin', fn () => '')->name('admin.dashboard'); // Excluded by options
+
+    artisan('ziggy:generate --only=postComments.index,slashes');
+
+    expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
+});
+
+test('generate file using both --only and --except', function () {
+    Route::get('posts/{post}/comments', fn () => '')->name('postComments.index');
+    Route::get('slashes/{slug}', fn () => '')->where('slug', '.*')->name('slashes');
+
+    artisan('ziggy:generate --only=slashes --except=postComments.index');
+
+    // Options cancel each other out and are ignored
     expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
 });
 

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -66,6 +66,16 @@ test('generate file respecting config', function () {
     expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
 });
 
+test('generate file respecting exclude options', function () {
+    Route::get('posts/{post}/comments', fn () => '')->name('postComments.index');
+    Route::get('slashes/{slug}', fn () => '')->where('slug', '.*')->name('slashes');
+    Route::get('admin', fn () => '')->name('admin.dashboard'); // Excluded by options
+
+    artisan('ziggy:generate --except=admin.*');
+
+    expect(base_path('resources/js/ziggy.js'))->toEqualFile('./tests/fixtures/ziggy.js');
+});
+
 test('generate file with custom output formatter', function () {
     Route::get('posts/{post}/comments', fn () => '')->name('postComments.index');
     Route::get('admin', fn () => '')->name('admin.dashboard'); // Excluded by config
@@ -162,7 +172,7 @@ test('generate correct routes and dts files based on provided arguments', functi
 
 class CustomFile extends File
 {
-    function __toString(): string
+    public function __toString(): string
     {
         return <<<JAVASCRIPT
         // This is a custom template


### PR DESCRIPTION
This PR adds the ability to pass `--except` and `--only` args to the artisan command.

The reason for this is I have developed a [vite plugin](https://github.com/aniftyco/vite-plugin-ziggy) for auto generating of your ziggy routes and types when any changes happen to `routes/` files and it would be nice to be able to just `composer require tightenco/ziggy` then `npm i -D vite-plugin-ziggy` and add the plugin to your vite config and it just works.

I have this setup to respect config as usual, but if you pass one of the args to the command that takes precidence over the same key in the config.

Only supports `except/only`, the rest should delegate to the config if you want to get that deep, in which case if you don't pass an `except` or `only` key to my plugin, it won't pass down to the command allowing ziggy to work as always. 