### PR TITLE
Fix `current()` type in strict mode

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -170,12 +170,12 @@ interface ParsedQs {
  * Ziggy's Router class.
  */
 interface Router {
-    current(): RouteName | undefined;
-    current<T extends RouteName>(name: T, params?: ParameterValue | RouteParams<T>): boolean;
+    current(): ValidRouteName | undefined;
+    current<T extends ValidRouteName>(name: T, params?: ParameterValue | RouteParams<T>): boolean;
     get params(): Record<string, string>;
     get routeParams(): Record<string, string>;
     get queryParams(): ParsedQs;
-    has<T extends RouteName>(name: T): boolean;
+    has<T extends ValidRouteName>(name: T): boolean;
 }
 
 /**


### PR DESCRIPTION
Updates `route().current()` and `route().has()` to use the new `ValidRouteName` type so they only return or accept known route names in strict mode. Technically `route().current()` should _always_ only return known route names, but I don't think we can actually use the `KnownRouteName` type because the interface it looks in for route names could be empty if the user hasn't run the command to generate it.

Fixes #808.