### PR TITLE
Rename generated types file

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -50,7 +50,7 @@ class CommandRouteGenerator extends Command
         if ($this->option('types') || $this->option('types-only')) {
             $types = config('ziggy.output.types', Types::class);
 
-            $filesystem->put(base_path("{$name}.d.ts"), new $types($ziggy));
+            $filesystem->put(base_path("{$name}-types.d.ts"), new $types($ziggy));
         }
 
         $this->info('Files generated!');


### PR DESCRIPTION
Rename generated types file by adding `-types` to resolve issue discussed here #702