### PR TITLE
Fix checking current route in strict mode

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -171,7 +171,7 @@ interface ParsedQs {
  */
 interface Router {
     current(): ValidRouteName | undefined;
-    current<T extends ValidRouteName>(name: T, params?: ParameterValue | RouteParams<T>): boolean;
+    current<T extends RouteName>(name: T, params?: ParameterValue | RouteParams<T>): boolean;
     get params(): Record<string, string>;
     get routeParams(): Record<string, string>;
     get queryParams(): ParsedQs;

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -89,6 +89,8 @@ assertType(route().has(''));
 // Test router getter autocompletion
 assertType(route().params);
 
+// These should NOT error in strict mode
+assertType(route().current('posts.*'));
 assertType(route().current('missing', { foo: 1 }));
 
 // @ts-expect-error missing required 'post' parameter


### PR DESCRIPTION
Fixes a regression introduced in #809 that broke wildcards in `route().current()`. `route().current()` should **return** a valid route name in strict mode, but `route().current('...')` needs to **accept** any argument so that we can check wildcards.