### PR TITLE
Switch package dependency from laravel/framework to Illuminate components to improve compatibility with Sage Theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "laravel/framework": ">=9.0"
+        "illuminate/routing": ">=9.0",
+        "illuminate/support": ">=9.0",
+        "illuminate/container": ">=9.0",
+        "illuminate/contracts": ">=9.0"
     },
     "require-dev": {
         "laravel/folio": "^1.1",


### PR DESCRIPTION
### 🔄 What

This PR changes Ziggy’s composer dependency from the full `laravel/framework` to only the required Illuminate components:

- Removed `laravel/framework: >=9.0`
- Added:
  - `illuminate/routing: >=9.0`
  - `illuminate/support: >=9.0`
  - `illuminate/container: >=9.0`
  - `illuminate/contracts: >=9.0`

The package now works without relying on the entire Laravel framework.

### ✅ Why

1. **Compatibility with Sage Theme / Acorn**  
   Sage (from Roots) is built on component-based Laravel (via Acorn) and doesn't load the full framework. By removing `laravel/framework`, we avoid namespace conflicts and incompatible duplicates.

2. **Eliminating unnecessary dependencies**  
   When Ziggy is used in projects that already include Illuminate components (e.g., Acorn), pulling in the entire framework is redundant and increases package size.

3. **Modular and lightweight**  
   This aligns with best practices—only include what is needed, improving performance and reducing risk of dependency clashes.

### ⚠️ Compatibility

- Minimal change impact; code continues to function with Laravel 9/10/11.
- Upgrading only component versions—no breaking changes expected.
- Verified imports remain valid for typical usage scenarios.

### ✅ Testing

- Clean Laravel 9 install: `composer update`, `php artisan ziggy:generate`—all good.
- Sage Theme + Acorn setup: verified route generation and integration without full framework.
- Confirmed no duplicate class issues and correct behaviour in component-driven envs.

---

Feel free to review and let me know if you'd like any tweaks or additional tests before merging!
