### PR TITLE
Add Config class for Ziggy configuration management (dynamic configuration)

### DIFF
--- a/src/js/Config.js
+++ b/src/js/Config.js
@@ -180,17 +180,22 @@ export default class Config {
      * @return {Object}
      */
     get location() {
-        const {
-            host = '',
-            pathname = '',
-            search = '',
-        } = typeof window !== 'undefined' ? window.location : {};
+        const windowLocation = typeof window !== 'undefined' ? window.location : {};
+        let configLocation = this._config.location || {};
 
-        const location = this._config.location ?? {};
+        if (typeof configLocation === 'string') {
+            try {
+                const { host, pathname, search } = new URL(configLocation);
+                configLocation = { host, pathname, search };
+            } catch (e) {
+                configLocation = {};
+            }
+        }
 
         return {
-            ...{ host, pathname, search },
-            ...location,
+            host: configLocation.host ?? windowLocation.host ?? '',
+            pathname: configLocation.pathname ?? windowLocation.pathname ?? '',
+            search: configLocation.search ?? windowLocation.search ?? '',
         };
     }
 

--- a/src/js/Config.js
+++ b/src/js/Config.js
@@ -1,0 +1,205 @@
+/**
+ * Configuration manager for Ziggy routes.
+ */
+export default class Config {
+    /**
+     * Default configuration getter function.
+     *
+     * @private
+     * @static
+     * @type {Function}
+     */
+    static _configGetter = () => (typeof Ziggy !== 'undefined' ? Ziggy : globalThis?.Ziggy);
+
+    /**
+     * Default absolute URL flag.
+     *
+     * @private
+     * @static
+     * @type {Boolean}
+     */
+    static _absolute = true;
+
+    /**
+     * Create a new Config instance.
+     *
+     * @param {Object} [config] - Configuration object. If null, uses _configGetter.
+     * @param {Boolean} [absolute] - Whether to use absolute URLs.
+     * @throws {Error} If no configuration is provided and no global Ziggy object is defined.
+     */
+    constructor(config, absolute) {
+        config = config || Config._configGetter();
+
+        if (!config) {
+            throw new Error('Ziggy error: Missing config. define `Ziggy` globally or pass it.');
+        }
+
+        absolute = typeof absolute !== 'undefined' ? absolute : Config._absolute;
+
+        this._config = { ...config, absolute };
+    }
+
+    /**
+     * Get the default Ziggy configuration.
+     *
+     * @return {Object|undefined} The configuration object.
+     */
+    static get() {
+        return Config._configGetter();
+    }
+
+    /**
+     * Set the default Ziggy configuration.
+     *
+     * @static
+     * @param {Object|Function} config - Set Ziggy configuration object or getter function.
+     * @throws {Error} If the config is not an object or a function.
+     */
+    static set(config) {
+        if (typeof config === 'function') {
+            Config._configGetter = config;
+        } else if (typeof config === 'object' && config !== null) {
+            Config._configGetter = () => config;
+        } else {
+            throw new Error('Ziggy error: Invalid config type. Expected an object or a function.');
+        }
+    }
+
+    /**
+     * Set the default absolute URL flag.
+     *
+     * @static
+     * @param {Boolean} absolute - Whether to use absolute URLs.
+     */
+    static absolute(absolute) {
+        Config._absolute = Boolean(absolute);
+    }
+
+    /**
+     * Get the entire configuration object.
+     *
+     * @return {Object}
+     */
+    all() {
+        return this._config;
+    }
+
+    /**
+     * Get the base URL from the configuration.
+     *
+     * @return {String}
+     */
+    get url() {
+        return this._config.url;
+    }
+
+    /**
+     * Get the protocol of url with delimiter.
+     *
+     * @example
+     * 'http://'
+     * 'https://'
+     *
+     * @return {String}
+     */
+    get protocol() {
+        return this.url.match(/^\w+:\/\//)[0];
+    }
+
+    /**
+     * Get the port from the configuration.
+     *
+     * @return {Number|null}
+     */
+    get port() {
+        return this._config.port;
+    }
+
+    /**
+     * Get the defaults from the configuration.
+     *
+     * @return {Object}
+     */
+    get defaults() {
+        return this._config.defaults;
+    }
+
+    /**
+     * Picks specific keys from default parameters.
+     *
+     * @param {string[]} [keys] - An array of keys.
+     * @return {Object}
+     */
+    default(keys) {
+        const defaults = this.defaults || {};
+
+        return keys.reduce((result, key) => {
+            if (defaults.hasOwnProperty(key)) result[key] = defaults[key];
+
+            return result;
+        }, {});
+    }
+
+    /**
+     * Get the routes from the configuration.
+     *
+     * @return {Object}
+     */
+    get routes() {
+        return this._config.routes;
+    }
+
+    /**
+     * Get a specific route by name.
+     *
+     * @param {String} [name] - The route name to retrieve.
+     * @return {Object}
+     * @throws {Error} If the route does not exist.
+     */
+    route(name) {
+        if (!this.hasRoute(name)) {
+            throw new Error(`Ziggy error: route '${name}' is not in the route list.`);
+        }
+
+        return this.routes[name];
+    }
+
+    /**
+     * Check if a route exists.
+     *
+     * @param {String} [name] - The route name to check.
+     * @return {Boolean}
+     */
+    hasRoute(name) {
+        return this.routes.hasOwnProperty(name);
+    }
+
+    /**
+     * Get the location from the configuration.
+     *
+     * @return {Object}
+     */
+    get location() {
+        const {
+            host = '',
+            pathname = '',
+            search = '',
+        } = typeof window !== 'undefined' ? window.location : {};
+
+        const location = this._config.location ?? {};
+
+        return {
+            ...{ host, pathname, search },
+            ...location,
+        };
+    }
+
+    /**
+     * Get the absolute flag from the configuration.
+     *
+     * @return {Boolean}
+     */
+    get absolute() {
+        return this._config.absolute;
+    }
+}

--- a/src/js/Route.js
+++ b/src/js/Route.js
@@ -1,4 +1,5 @@
 import { parse } from 'qs';
+import Config from './Config.js';
 
 /**
  * A Laravel route. This class represents one route and its configuration and metadata.
@@ -7,7 +8,7 @@ export default class Route {
     /**
      * @param {String} name - Route name.
      * @param {Object} definition - Route definition.
-     * @param {Object} config - Ziggy configuration.
+     * @param {Config} config - Ziggy configuration.
      */
     constructor(name, definition, config) {
         this.name = name;
@@ -45,7 +46,7 @@ export default class Route {
         return !this.config.absolute
             ? ''
             : this.definition.domain
-              ? `${this.config.url.match(/^\w+:\/\//)[0]}${this.definition.domain}${
+              ? `${this.config.protocol}${this.definition.domain}${
                     this.config.port ? `:${this.config.port}` : ''
                 }`
               : this.config.url;

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -1,5 +1,6 @@
 import { stringify } from 'qs';
 import Route from './Route.js';
+import Config from './Config.js';
 
 /**
  * A collection of Laravel routes. This class constitutes Ziggy's main API.
@@ -10,19 +11,16 @@ export default class Router extends String {
      * @param {(String|Number|Array|Object)} [params] - Route parameters.
      * @param {Boolean} [absolute] - Whether to include the URL origin.
      * @param {Object} [config] - Ziggy configuration.
+     * @throws {Error} If no configuration is provided and no global Ziggy object is defined.
+     * @throws {Error} If the route name is not found in the configuration.
      */
-    constructor(name, params, absolute = true, config) {
+    constructor(name, params, absolute, config) {
         super();
 
-        this._config = config ?? (typeof Ziggy !== 'undefined' ? Ziggy : globalThis?.Ziggy);
-        this._config = { ...this._config, absolute };
+        this._config = new Config(config, absolute);
 
         if (name) {
-            if (!this._config.routes[name]) {
-                throw new Error(`Ziggy error: route '${name}' is not in the route list.`);
-            }
-
-            this._route = new Route(name, this._config.routes[name], this._config);
+            this._route = new Route(name, this._config.route(name), this._config);
             this._params = this._parse(params);
         }
     }
@@ -71,7 +69,7 @@ export default class Router extends String {
         } else if (this._config.absolute && url.startsWith('/')) {
             // If we are using absolute URLs and a relative URL
             // is passed, prefix the host to make it absolute
-            url = this._location().host + url;
+            url = this._config.location.host + url;
         }
 
         let matchedParams = {};
@@ -84,7 +82,7 @@ export default class Router extends String {
     }
 
     _currentUrl() {
-        const { host, pathname, search } = this._location();
+        const { host, pathname, search } = this._config.location;
 
         return (
             (this._config.absolute
@@ -162,26 +160,6 @@ export default class Router extends String {
     }
 
     /**
-     * Get an object representing the current location (by default this will be
-     * the JavaScript `window` global if it's available).
-     *
-     * @return {Object}
-     */
-    _location() {
-        const {
-            host = '',
-            pathname = '',
-            search = '',
-        } = typeof window !== 'undefined' ? window.location : {};
-
-        return {
-            host: this._config.location?.host ?? host,
-            pathname: this._config.location?.pathname ?? pathname,
-            search: this._config.location?.search ?? search,
-        };
-    }
-
-    /**
      * Get all parameter values from the current window URL.
      *
      * @example
@@ -211,7 +189,7 @@ export default class Router extends String {
      * @return {Boolean}
      */
     has(name) {
-        return this._config.routes.hasOwnProperty(name);
+        return this._config.hasRoute(name);
     }
 
     /**
@@ -261,29 +239,12 @@ export default class Router extends String {
             params = { [segments[0].name]: params };
         }
 
+        const parameterNames = route.parameterSegments.map(({ name }) => name);
+
         return {
-            ...this._defaults(route),
+            ...this._config.default(parameterNames),
             ...this._substituteBindings(params, route),
         };
-    }
-
-    /**
-     * Populate default parameters for the given route.
-     *
-     * @example
-     * // with default parameters { locale: 'en', country: 'US' } and 'posts.show' route '{locale}/posts/{post}'
-     * defaults(...); // { locale: 'en' }
-     *
-     * @param {Route} route
-     * @return {Object} Default route parameters.
-     */
-    _defaults(route) {
-        return route.parameterSegments
-            .filter(({ name }) => this._config.defaults[name])
-            .reduce(
-                (result, { name }, i) => ({ ...result, [name]: this._config.defaults[name] }),
-                {},
-            );
     }
 
     /**

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -154,11 +154,13 @@ interface Config {
     port: number | null;
     defaults: Record<string, RawParameterValue>;
     routes: Record<string, Route>;
-    location?: {
-        host?: string;
-        pathname?: string;
-        search?: string;
-    };
+    location?:
+        | string
+        | {
+              host?: string;
+              pathname?: string;
+              search?: string;
+          };
 }
 
 // qs's parsed query params type, so we don't have to have qs as a dependency

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -208,6 +208,26 @@ export function route<T extends ValidRouteName>(
 ): string;
 
 /**
+ * Configuration manager for Ziggy.
+ */
+export declare class ZiggyConfig {
+    /**
+     * Get the default Ziggy configuration.
+     */
+    static get(): Config | null;
+
+    /**
+     * Set the default Ziggy configuration.
+     */
+    static set(config: Config | (() => Config)): void;
+
+    /**
+     * Set the default absolute URL flag.
+     */
+    static absolute(absolute: boolean): void;
+}
+
+/**
  * Ziggy's Vue plugin.
  */
 export const ZiggyVue: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
 import Router from './Router.js';
+import ZiggyConfig from './Config.js';
 
 export function route(name, params, absolute, config) {
     const router = new Router(name, params, absolute, config);
@@ -34,3 +35,5 @@ export function useRoute(defaultConfig) {
     return (name, params, absolute, config = defaultConfig) =>
         route(name, params, absolute, config);
 }
+
+export { ZiggyConfig };

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
-import { route } from '../../src/js';
+import { route, ZiggyConfig } from '../../src/js';
 // import { route } from '../../dist/index.esm.js';
 // import { route } from '../../dist/index.js';
 // import route from '../../dist/route.umd.js';
@@ -837,6 +837,106 @@ describe('route()', () => {
 
         // Laravel does encode '$', but encodeURI() doesn't
         expect(route('pages', 'a$b')).toBe('https://ziggy.dev/a%24b');
+    });
+});
+
+describe('route() with ZiggyConfig', () => {
+    const customConfig = {
+        url: 'https://config.ziggy.dev',
+        port: null,
+        defaults: { theme: 'dark' },
+        routes: {
+            home: {
+                uri: 'dashboard',
+                methods: ['GET', 'HEAD'],
+            },
+            'page.show': {
+                uri: 'page/{id}',
+                methods: ['GET', 'HEAD'],
+            },
+        },
+    };
+
+    beforeEach(() => {
+        // Reset any global Config settings before each test
+        ZiggyConfig.set(() => customConfig);
+        ZiggyConfig.absolute(true);
+        delete global.Ziggy;
+    });
+
+    test('can set default configuration using ZiggyConfig.set() with function', () => {
+        expect(route('home')).toBe('https://config.ziggy.dev/dashboard');
+    });
+
+    test('can set default configuration using ZiggyConfig.set() with object', () => {
+        ZiggyConfig.set(customConfig);
+
+        expect(route('page.show', { id: 1 })).toBe('https://config.ziggy.dev/page/1');
+    });
+
+    test('can get default configuration using ZiggyConfig.get()', () => {
+        expect(ZiggyConfig.get()).toEqual(customConfig);
+    });
+
+    test('can set default absolute URL flag using ZiggyConfig.absolute()', () => {
+        ZiggyConfig.absolute(false);
+
+        expect(route('home')).toBe('/dashboard');
+    });
+
+    test('can override default config object per route call', () => {
+        const defaultZiggy = {
+            url: 'https://ziggy.dev',
+            port: null,
+            defaults: { locale: 'en' },
+            routes: {
+                home: {
+                    uri: '/',
+                    methods: ['GET', 'HEAD'],
+                },
+            },
+        };
+
+        // Override default config
+        expect(route('home', undefined, undefined, defaultZiggy)).toBe('https://ziggy.dev');
+
+        // Use default
+        expect(route('home')).toBe('https://config.ziggy.dev/dashboard');
+    });
+
+    test('can override default absolute flag per route call', () => {
+        ZiggyConfig.absolute(false);
+
+        // Override default absolute flag
+        expect(route('page.show', { id: 2 }, true)).toBe('https://config.ziggy.dev/page/2');
+
+        // Use default
+        expect(route('page.show', { id: 2 })).toBe('/page/2');
+    });
+
+    test('ZiggyConfig.set() throws error for invalid config type', () => {
+        expect(() => ZiggyConfig.set()).toThrow(
+            'Ziggy error: Invalid config type. Expected an object or a function.',
+        );
+
+        expect(() => ZiggyConfig.set('invalid')).toThrow(
+            'Ziggy error: Invalid config type. Expected an object or a function.',
+        );
+
+        expect(() => ZiggyConfig.set(123)).toThrow(
+            'Ziggy error: Invalid config type. Expected an object or a function.',
+        );
+
+        expect(() => ZiggyConfig.set(true)).toThrow(
+            'Ziggy error: Invalid config type. Expected an object or a function.',
+        );
+    });
+
+    test('ZiggyConfig.get() returns undefined when no global Ziggy config is set', () => {
+        // Reset config back to default global getter
+        ZiggyConfig.set(() => (typeof Ziggy !== 'undefined' ? Ziggy : globalThis?.Ziggy));
+
+        expect(ZiggyConfig.get()).toBeUndefined();
     });
 });
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -611,6 +611,28 @@ describe('route()', () => {
         );
     });
 
+    test('can accept string location from Ziggy configuration', () => {
+        global.Ziggy.location = 'https://ziggy.dev/events/1/venues/2?vip=true';
+
+        global.window.location.host = 'ziggy.dev';
+        global.window.location.pathname = '/posts/4';
+        global.window.location.search = '?vip=false';
+
+        expect(route().params).toStrictEqual({ event: '1', venue: '2', vip: 'true' });
+    });
+
+    test('can handle invalid string location from Ziggy configuration', () => {
+        global.Ziggy.location = 'invalid-url';
+
+        global.window.location.host = 'ziggy.dev';
+        global.window.location.pathname = '/posts/4';
+        global.window.location.search = '?vip=false';
+
+        // Should work normally when string location is invalid
+        expect(() => route()).not.toThrow();
+        expect(route().params).toStrictEqual({ post: '4', vip: 'false' });
+    });
+
     test('can extract parameters for an app installed in a subfolder', () => {
         global.Ziggy.url = 'https://ziggy.dev/subfolder';
 


### PR DESCRIPTION
#### Summary
* Introduced a `Config` class to manage Ziggy configuration.
* Added static `set()`, `get()` and `absolute()` methods for default configuration.
* Updated `Route` and `Router` classes to use the new `Config` class.
* Added tests to ensure the config behavior is consistent and reliable.

#### Purpose
The main goal of this PR is to allow **dynamic configuration** of Ziggy at runtime by setting a config getter:

```js
 // Inertia example
ZiggyConfig.set(() => usePage().props.ziggy);
 // DOM-based config
ZiggyConfig.set(() => JSON.parse(document.getElementById('ziggy-routes-json').textContent));

// Set default absolute flag
ZiggyConfig.absolute(false)
```

This makes Ziggy more flexible by allowing dynamic configuration instead of relying on a static one.
