### PR TITLE
Fix current checks with encoded `#` in URL

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -150,7 +150,9 @@ export default class Router extends String {
         const isSubset = (subset, full) => {
             return Object.entries(subset).every(([key, value]) => {
                 if (Array.isArray(value) && Array.isArray(full[key])) {
-                    return value.every((v) => full[key].includes(v));
+                    return value.every(
+                        (v) => full[key].includes(v) || full[key].includes(decodeURIComponent(v)),
+                    );
                 }
 
                 if (
@@ -162,7 +164,7 @@ export default class Router extends String {
                     return isSubset(value, full[key]);
                 }
 
-                return full[key] == value;
+                return full[key] == value || full[key] == decodeURIComponent(value);
             });
         };
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1504,8 +1504,17 @@ describe('current()', () => {
     });
 
     // https://github.com/tighten/ziggy/issues/844
-    test('url containing hash', () => {
+    test('url containing encoded hash', () => {
         global.window.location.pathname = '/slashes/foo/Arcbees_c%23_doc.md';
+
+        expect(route().current()).toBe('slashes');
+        expect(route().current('slashes', { slug: 'Arcbees_c#_doc.md' })).toBe(true);
+        expect(route().current('slashes', { slug: 'Arcbees_c%23_doc.md' })).toBe(true);
+    });
+
+    test('url containing raw hash', () => {
+        // This specific case doesn't really matter because it's not valid, # is a URL anchor and can't be in the path like this
+        global.window.location.pathname = '/slashes/foo/Arcbees_c#_doc.md';
 
         expect(route().current()).toBe('slashes');
         expect(route().current('slashes', { slug: 'Arcbees_c#_doc.md' })).toBe(true);

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1502,6 +1502,15 @@ describe('current()', () => {
 
         global.window = oldWindow;
     });
+
+    // https://github.com/tighten/ziggy/issues/844
+    test('url containing hash', () => {
+        global.window.location.pathname = '/slashes/foo/Arcbees_c%23_doc.md';
+
+        expect(route().current()).toBe('slashes');
+        expect(route().current('slashes', { slug: 'Arcbees_c#_doc.md' })).toBe(true);
+        expect(route().current('slashes', { slug: 'Arcbees_c%23_doc.md' })).toBe(true);
+    });
 });
 
 describe('json', () => {

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -1513,7 +1513,8 @@ describe('current()', () => {
     });
 
     test('url containing raw hash', () => {
-        // This specific case doesn't really matter because it's not valid, # is a URL anchor and can't be in the path like this
+        // This specific case may not matter because it's not valid, # is a URL anchor and
+        // can't be in the path like this, but in general this should work both ways
         global.window.location.pathname = '/slashes/foo/Arcbees_c#_doc.md';
 
         expect(route().current()).toBe('slashes');


### PR DESCRIPTION
Adds support for checking current parameter values using encoded strings. Before, checking `foo_%23_bar` against a URL with `foo_%23_bar` would return false (both encoded), but checking `foo_#_bar` (decoded) against `foo_%23_bar` (encoded) would fail.

This wasn't working because internally Ziggy is resolving the current URL's params to their *de*coded value, which might be a mistake (especially here, because `#` means something very specific in a URL), but regardless this check should work.

Fixes #844.