### PR TITLE
Allow specifying the name of the typescript declaration file

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -12,7 +12,7 @@ class CommandRouteGenerator extends Command
 {
     protected $signature = 'ziggy:generate
                             {path? : Path to the generated JavaScript file. Default: `resources/js/ziggy.js`.}
-                            {--types : Generate a TypeScript declaration file.}
+                            {--types=false : Generate a TypeScript declaration file at the given path. Default: `resources/js/ziggy.d.ts`.}
                             {--types-only : Generate only a TypeScript declaration file.}
                             {--url=}
                             {--group=}
@@ -47,10 +47,15 @@ class CommandRouteGenerator extends Command
             $filesystem->put(base_path("{$name}.js"), new $output($ziggy));
         }
 
-        if ($this->option('types') || $this->option('types-only')) {
+        if ($this->option('types') !== 'false' || $this->option('types-only')) {
             $types = config('ziggy.output.types', Types::class);
 
-            $filesystem->put(base_path("{$name}.d.ts"), new $types($ziggy));
+            $typesPath = match ($this->option('types')) {
+                'false', null => config('ziggy.output.types-path', "{$name}.d.ts"),
+                default => $this->option('types'),
+            };
+
+            $filesystem->put(base_path($typesPath), new $types($ziggy));
         }
 
         $this->info('Files generated!');

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -157,6 +157,21 @@ test('generate dts file', function () {
     expect(base_path('resources/js/ziggy.d.ts'))->toEqualFile('./tests/fixtures/ziggy.d.ts');
 });
 
+test('generate dts file at custom path', function () {
+    artisan('ziggy:generate --types=resources/js/custom.d.ts');
+
+    expect(base_path('resources/js/custom.d.ts'))->toBeFile();
+});
+
+test('generate dts file at path set in config', function () {
+    config(['ziggy.output.types-path' => 'resources/js/types.d.ts']);
+
+    artisan('ziggy:generate --types');
+
+    expect(base_path('resources/js/ziggy.js'))->toBeFile();
+    expect(base_path('resources/js/types.d.ts'))->toBeFile();
+});
+
 test('generate dts file without generating routes file', function () {
     artisan('ziggy:generate --types-only');
 
@@ -184,6 +199,7 @@ test('generate correct routes and dts files based on provided arguments', functi
     expect(array_map(base_path(...), $files))->each->toBeFile();
 })->with([
     ['resources/js/x.js --types', ['resources/js/x.js', 'resources/js/x.d.ts']],
+    ['resources/js/x.js --types=resources/js/t.d.ts', ['resources/js/x.js', 'resources/js/t.d.ts']],
     ['resources/js/y.ts --types', ['resources/js/y.js', 'resources/js/y.d.ts']],
     ['resources/js/z.d.ts --types', ['resources/js/z.js', 'resources/js/z.d.ts']],
     ['resources/scripts/foo --types', ['resources/scripts/foo.js', 'resources/scripts/foo.d.ts']],


### PR DESCRIPTION
Allows passing a value to the `--types` command option to put the types at a custom path instead of `resources/js/ziggy.d.ts`. This is a bandaid solution for the 'module has no exported member Ziggy' issue, which I believe really does just boil down to the files being named the same, which they shouldn't be. I think changing the default name is a breaking change though, so adding this in the meantime.

**To fix the issue described in #828, #829, and #826, use `--types=resources/js/ziggy-routes.d.ts` in your commands** (or another path that is not `resources/js/ziggy.d.ts`).

The default in the command signature is `"false"` to remain compatible with existing command usage that either:

- doesn't pass the `--types` option at all (in which case the command will now see `"false"` and not generate types)
- passes `--types` just like that, with no value (in which case the command will see it as `null` and generate types at the default location)

Closes #828.