### PR TITLE
Fix shared route bindings mutation in _substituteBindings

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -321,18 +321,19 @@ export default class Router extends String {
                 return { ...result, [key]: value };
             }
 
-            if (!value.hasOwnProperty(bindings[key])) {
-                if (value.hasOwnProperty('id')) {
-                    // As a fallback, we still accept an 'id' key not explicitly registered as a binding
-                    bindings[key] = 'id';
-                } else {
-                    throw new Error(
-                        `Ziggy error: object passed as '${key}' parameter is missing route model binding key '${bindings[key]}'.`,
-                    );
-                }
+            const binding = value.hasOwnProperty(bindings[key])
+                ? bindings[key]
+                : value.hasOwnProperty('id')
+                  ? 'id'
+                  : undefined;
+
+            if (binding === undefined) {
+                throw new Error(
+                    `Ziggy error: object passed as '${key}' parameter is missing route model binding key '${bindings[key]}'.`,
+                );
             }
 
-            return { ...result, [key]: value[bindings[key]] };
+            return { ...result, [key]: value[binding] };
         }, {});
     }
 

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -437,6 +437,16 @@ describe('route()', () => {
         );
     });
 
+    test("falling back to 'id' key does not mutate registered route model bindings", () => {
+        expect(route('postComments.show', [1, { id: 1 }])).toBe(
+            'https://ziggy.dev/posts/1/comments/1',
+        );
+
+        expect(route('postComments.show', [1, { id: 1, uuid: '1-2-3' }])).toBe(
+            'https://ziggy.dev/posts/1/comments/1-2-3',
+        );
+    });
+
     test('can generate a URL for an app installed in a subfolder', () => {
         global.Ziggy.url = 'https://ziggy.dev/subfolder';
 


### PR DESCRIPTION
When `_substituteBindings` encounters an object missing its registered binding key (e.g. `slug`), it falls back to `id` — but it does so by writing `bindings[key] = 'id'` directly on the shared route definition. This permanently overwrites the original binding for all subsequent calls.

For example, with a `posts.show` route bound to `slug`:

```js
// First call — partial object, no slug, falls back to id
route('posts.show', { post: { id: 1 } });
// 'https://example.com/posts/1' ✓

// Second call — full object with slug
route('posts.show', { post: { id: 1, slug: 'hello-world' } });
// Expected: 'https://example.com/posts/hello-world'
// Actual:   'https://example.com/posts/1' ✗
```

The second call uses `id` instead of `slug` because the first call mutated the route config.

This PR replaces the mutation with a local variable so the fallback is resolved per-call.