### PR TITLE
fix: handle falsy parameter values in _parse

### DIFF
--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -263,7 +263,7 @@ export default class Router extends String {
             );
         } else if (
             segments.length === 1 &&
-            !params[segments[0].name] &&
+            !params.hasOwnProperty(segments[0].name) &&
             (params.hasOwnProperty(Object.values(route.bindings)[0]) || params.hasOwnProperty('id'))
         ) {
             // If there is only one template segment and `params` is an object, that object is

--- a/tests/js/route.test.js
+++ b/tests/js/route.test.js
@@ -593,6 +593,10 @@ describe('route()', () => {
         expect(route('posts.update', 0)).toBe('https://ziggy.dev/posts/0');
     });
 
+    test('can handle an object parameter with a falsy value for the segment name', () => {
+        expect(route('posts.show', { post: 0 })).toBe('https://ziggy.dev/posts/0');
+    });
+
     test('can accept a custom Ziggy configuration object', () => {
         const config = {
             url: 'http://notYourAverage.dev',


### PR DESCRIPTION
## Summary

- Fixes a bug where `route('posts.show', { post: 0 })` would incorrectly wrap params to `{ post: { post: 0 } }` because the truthiness check `!params[segments[0].name]` treats `0` as falsy
- Replaced with `!params.hasOwnProperty(segments[0].name)` to check for key presence instead of truthiness
- Added a test case for this scenario

## Example

```js
// Route: 'posts/{post}'
route('posts.show', { post: 0 });
// Before: !params['post'] → !0 → true, so params gets wrapped to { post: { post: 0 } }
// After:  !params.hasOwnProperty('post') → false, so params stays as { post: 0 } ✓
```

## Test plan

- [x] New test: `can handle an object parameter with a falsy value for the segment name`
- [x] All existing tests pass (`npx vitest --typecheck`)