### PR TITLE
Fix TypeError when optional params omitted from array (fixes #736)

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -114,16 +114,28 @@ type RouteParamsObject<N extends RouteName> = N extends KnownRouteName
 type GenericRouteParamsArray = unknown[];
 /**
  * An array of parameters for a specific named route.
+ *
+ * Required parameters come first as required tuple elements, then optional
+ * parameters become optional tuple elements, followed by arbitrary extras.
  */
 type KnownRouteParamsArray<I extends readonly ParameterInfo[]> = [
-    ...{ [K in keyof I]: Routable<I[K]> },
-    ...unknown[],
+    ...RequiredParamsTuple<I>,
+    ...OptionalParamsTuple<I>,
 ];
-// Because `K in keyof I` for a `readonly` array is always a number, even though this
-// looks like `{ 0: T, 1: U, 2: V }` TypeScript generates `[T, U, V]`. The nested
-// array destructing lets us type the first n items in the array, which are known
-// route parameters, and then allow arbitrary additional items.
-// See https://github.com/tighten/ziggy/pull/664#discussion_r1330002370.
+
+type RequiredParamsTuple<I extends readonly ParameterInfo[]> =
+    I extends readonly [infer F extends ParameterInfo, ...infer R extends ParameterInfo[]]
+        ? F extends { required: true }
+            ? [Routable<F>, ...RequiredParamsTuple<R>]
+            : []
+        : [];
+
+type OptionalParamsTuple<I extends readonly ParameterInfo[]> =
+    I extends readonly [infer F extends ParameterInfo, ...infer R extends ParameterInfo[]]
+        ? F extends { required: false }
+            ? [Routable<F>?, ...OptionalParamsTuple<R>]
+            : OptionalParamsTuple<R>
+        : [...unknown[]];
 
 // Uncomment to test:
 // type B = KnownRouteParamsArray<[{ name: 'post'; required: true; binding: 'uuid' }]>;

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -65,12 +65,12 @@ assertType(route('posts.comments.show', 'foo'));
 assertType(route('posts.comments.show'));
 
 // Simple array examples
-// assertType(route('posts.comments.show', [2])); // TODO shouldn't error, only one required param
+assertType(route('posts.comments.show', [2]));
 assertType(route('posts.comments.show', [2, 3]));
-// assertType(route('posts.comments.show', ['foo'])); // TODO shouldn't error, only one required param
+assertType(route('posts.comments.show', ['foo']));
 assertType(route('posts.comments.show', ['foo', 'bar']));
 // Allows mix of plain values and parameter objects
-// assertType(route('posts.comments.show', [{ id: 2 }])); // TODO shouldn't error, only one required param
+assertType(route('posts.comments.show', [{ id: 2 }]));
 assertType(route('posts.comments.show', [{ id: 2 }, 3]));
 assertType(route('posts.comments.show', ['2', { uuid: 3 }]));
 assertType(route('posts.comments.show', [{ id: 2 }, { uuid: '3' }]));
@@ -105,8 +105,12 @@ assertType(route().current('missing', { foo: 1 }));
 assertType(route().current('posts.comments.show', { comment: 2 }));
 assertType(route().current('posts.comments.show', { post: 2 }));
 assertType(route().current('posts.comments.show', 2));
-// assertType(route().current('posts.comments.show', [2])); // TODO shouldn't error, only one required param
+assertType(route().current('posts.comments.show', [2]));
 assertType(route().current('posts.comments.show', 'foo'));
+
+// All-optional route with array params
+assertType(route('optional', []));
+assertType(route('optional', ['foo']));
 
 // Test route function return types
 assertType<string>(route('optional', { maybe: 'foo' }));


### PR DESCRIPTION
Closes #736

## Summary

When passing route parameters as an array, omitting optional parameters caused a TypeScript error — even though the parameters were optional. This PR fixes that by making optional parameters truly optional in the generated tuple type.

### Before

Given a route like:

```ts
interface RouteList {
    'posts.comments.show': [
        { name: 'post'; required: true },
        { name: 'comment'; required: false },
    ];
}
```

These perfectly valid calls would all cause type errors:

```ts
route('posts.comments.show', [2]);        // ❌ Source has 1 element(s) but target requires 2
route('posts.comments.show', ['foo']);     // ❌
route('posts.comments.show', [{ id: 2 }]); // ❌
```

The workaround was to always pass all parameters or use object syntax instead.

### After

All of the above now work as expected — no type errors, no workarounds needed:

```ts
route('posts.comments.show', [2]);          // ✅
route('posts.comments.show', ['foo']);       // ✅
route('posts.comments.show', [{ id: 2 }]);  // ✅
route('posts.comments.show', [2, 3]);       // ✅ (still works too)
```

## How it works

The old `KnownRouteParamsArray` type mapped all parameters to required tuple positions regardless of whether they were optional. The fix splits it into two recursive helper types:

- **`RequiredParamsTuple`** — collects required params as required tuple elements
- **`OptionalParamsTuple`** — collects optional params as optional tuple elements (`?`), with `...unknown[]` at the end for extra items

So for the route above, the generated type goes from `[ParameterValue, ParameterValue, ...unknown[]]` to `[ParameterValue, ParameterValue?, ...unknown[]]`.

## Test plan

- Uncommented 4 existing TODO test cases that were previously blocked by this bug
- Added new tests for routes where all parameters are optional (`route('optional', [])` and `route('optional', ['foo'])`)
- All JS and type tests pass