### PR TITLE
Fix intellisense/completions for partial route parameter objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Ziggy – Use your Laravel routes in JavaScript
 
-[![GitHub Actions Status](https://img.shields.io/github/actions/workflow/status/tighten/ziggy/test.yml?branch=main&style=flat)](https://github.com/tighten/ziggy/actions?query=workflow:Test+branch:2.x)
+[![GitHub Actions Status](https://img.shields.io/github/actions/workflow/status/tighten/ziggy/test.yml?style=flat)](https://github.com/tighten/ziggy/actions/workflows/test.yml)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/tightenco/ziggy.svg?style=flat)](https://packagist.org/packages/tightenco/ziggy)
 [![Downloads on Packagist](https://img.shields.io/packagist/dt/tightenco/ziggy.svg?style=flat)](https://packagist.org/packages/tightenco/ziggy)
 [![Latest Version on NPM](https://img.shields.io/npm/v/ziggy-js.svg?style=flat)](https://npmjs.com/package/ziggy-js)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "qs-esm": "^7.0.3"
             },
             "devDependencies": {
+                "@types/node": "^25.3.5",
                 "jsdom": "^28.1.0",
                 "microbundle": "^0.15.1",
                 "prettier": "^3.8.1",
@@ -2973,13 +2974,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.2.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-            "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+            "version": "25.3.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+            "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/@types/parse-json": {
@@ -8322,9 +8323,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "qs-esm": "^7.0.3"
     },
     "devDependencies": {
+        "@types/node": "^25.3.5",
         "jsdom": "^28.1.0",
         "microbundle": "^0.15.1",
         "prettier": "^3.8.1",

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -202,14 +202,14 @@ interface Router {
 /**
  * Ziggy's route helper.
  */
-// Called with no arguments - returns a Router instance
+
+// Call with no arguments - returns a Router instance
 export function route(): Router;
 
-// Called with just a route name - returns a URL string
-// Separate from the overloads below to preserve route name autocompletion
+// Call with just a route name - returns a URL string (separate from below to preserve route name autocompletion)
 export function route(name: ValidRouteName): RouteUrl;
 
-// Called with a route name and parameters - returns a URL string
+// Call with a route name and parameters - returns a URL string
 export function route<T extends ValidRouteName>(
     name: T & {},
     params: RouteParams<T> | undefined,
@@ -217,8 +217,7 @@ export function route<T extends ValidRouteName>(
     config?: Config,
 ): RouteUrl;
 
-// Called with a route name and single parameter - returns a URL string
-// Separate from the overload above for better parameter autocompletion and more specific error messages
+// Call with a route name and single parameter - returns a URL string (separate from above for better parameter autocompletion and more specific error messages)
 export function route<T extends ValidRouteName>(
     name: T & {},
     params: ParameterValue | undefined,
@@ -226,7 +225,7 @@ export function route<T extends ValidRouteName>(
     config?: Config,
 ): RouteUrl;
 
-// Called with configuration arguments only - returns a configured Router instance
+// Call with configuration arguments only - returns a configured Router instance
 export function route(
     name: undefined,
     params: undefined,
@@ -234,7 +233,7 @@ export function route(
     config?: Config,
 ): Router;
 
-// Final overload to preserve flexible derived type shape
+// All allowed runtime calls (preserves flexible derived type shape)
 export function route<T extends ValidRouteName>(
     name?: T,
     params?: RouteParams<T> | ParameterValue,

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -234,6 +234,14 @@ export function route(
     config?: Config,
 ): Router;
 
+// Final overload to preserve flexible derived type shape
+export function route<T extends ValidRouteName>(
+    name?: T,
+    params?: RouteParams<T> | ParameterValue,
+    absolute?: boolean,
+    config?: Config,
+): RouteUrl | Router;
+
 /**
  * Ziggy's Vue plugin.
  */

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -205,17 +205,23 @@ interface Router {
 // Called with no arguments - returns a Router instance
 export function route(): Router;
 
-// Called with a route name and optional additional arguments - returns a URL string
+// Called with just a route name - returns a URL string
+// Separate from the overloads below to preserve route name autocompletion
+export function route(name: ValidRouteName): RouteUrl;
+
+// Called with a route name and parameters - returns a URL string
 export function route<T extends ValidRouteName>(
-    name: T,
-    params?: RouteParams<T> | undefined,
+    name: T & {},
+    params: RouteParams<T> | undefined,
     absolute?: boolean,
     config?: Config,
 ): RouteUrl;
 
+// Called with a route name and single parameter - returns a URL string
+// Separate from the overload above for better parameter autocompletion and more specific error messages
 export function route<T extends ValidRouteName>(
-    name: T,
-    params?: ParameterValue | undefined,
+    name: T & {},
+    params: ParameterValue | undefined,
     absolute?: boolean,
     config?: Config,
 ): RouteUrl;
@@ -224,8 +230,8 @@ export function route<T extends ValidRouteName>(
 export function route(
     name: undefined,
     params: undefined,
-    absolute: boolean | undefined,
-    config: Config,
+    absolute?: boolean,
+    config?: Config,
 ): Router;
 
 /**

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -205,14 +205,6 @@ interface Router {
 // Called with no arguments - returns a Router instance
 export function route(): Router;
 
-// Called with configuration arguments only - returns a configured Router instance
-export function route(
-    name: undefined,
-    params: undefined,
-    absolute?: boolean,
-    config?: Config,
-): Router;
-
 // Called with a route name and optional additional arguments - returns a URL string
 export function route<T extends ValidRouteName>(
     name: T,
@@ -227,6 +219,14 @@ export function route<T extends ValidRouteName>(
     absolute?: boolean,
     config?: Config,
 ): RouteUrl;
+
+// Called with configuration arguments only - returns a configured Router instance
+export function route(
+    name: undefined,
+    params: undefined,
+    absolute: boolean | undefined,
+    config: Config,
+): Router;
 
 /**
  * Ziggy's Vue plugin.

--- a/tests/js/completions.test.ts
+++ b/tests/js/completions.test.ts
@@ -83,7 +83,7 @@ function getCompletions(source: string, marker = '/*cursor*/') {
 }
 
 describe('TypeScript completions', () => {
-    test('suggests known route names', () => {
+    test('suggest known route names', () => {
         let completions = getCompletions(`
             route('/*cursor*/');
         `);
@@ -92,7 +92,7 @@ describe('TypeScript completions', () => {
         expect(completions).toContain('optional');
     });
 
-    test('suggests route params when a required param is still missing', () => {
+    test('suggest route params when a required param is still missing', () => {
         let completions = getCompletions(`
             route('posts.comments.show', {
                 /*cursor*/
@@ -104,7 +104,7 @@ describe('TypeScript completions', () => {
         expect(completions).toContain('_query');
     });
 
-    test('suggests remaining params after required params are provided', () => {
+    test('suggest remaining params after required params are provided', () => {
         let completions = getCompletions(`
             route('posts.comments.show', {
                 post: 1,
@@ -117,7 +117,7 @@ describe('TypeScript completions', () => {
         expect(completions).not.toContain('post');
     });
 
-    test('suggests optional params on all-optional routes', () => {
+    test('suggest optional params on all-optional routes', () => {
         let completions = getCompletions(`
             route('optional', {
                 /*cursor*/

--- a/tests/js/completions.test.ts
+++ b/tests/js/completions.test.ts
@@ -83,6 +83,15 @@ function getCompletions(source: string, marker = '/*cursor*/') {
 }
 
 describe('TypeScript completions', () => {
+    test('suggests known route names', () => {
+        let completions = getCompletions(`
+            route('/*cursor*/');
+        `);
+
+        expect(completions).toContain('posts.comments.show');
+        expect(completions).toContain('optional');
+    });
+
     test('suggests route params when a required param is still missing', () => {
         let completions = getCompletions(`
             route('posts.comments.show', {

--- a/tests/js/completions.test.ts
+++ b/tests/js/completions.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 
-const fixtureFile = resolve(process.cwd(), 'tests/js/__completions__.ts');
+const fixtureFile = resolve(__dirname, '__completions__.ts');
 
 function getCompletions(source: string, marker = '/*cursor*/') {
     if (!source.includes(marker)) {

--- a/tests/js/completions.test.ts
+++ b/tests/js/completions.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 
-const fixtureFile = resolve(__dirname, '__completions__.ts');
+const fixtureFile = resolve(__dirname, '__completions__.ts').replace(/\\/g, '/');
 
 function getCompletions(source: string, marker = '/*cursor*/') {
     if (!source.includes(marker)) {

--- a/tests/js/completions.test.ts
+++ b/tests/js/completions.test.ts
@@ -1,0 +1,121 @@
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, test } from 'vitest';
+
+const fixtureFile = resolve(process.cwd(), 'tests/js/__completions__.ts');
+
+function getCompletions(source: string, marker = '/*cursor*/') {
+    if (!source.includes(marker)) {
+        throw new Error(`Missing completion marker ${marker}`);
+    }
+
+    source = `
+        import { route } from '../../src/js';
+        declare module '../../src/js' {
+            interface RouteList {
+                'posts.comments.show': [
+                    { name: 'post'; required: true },
+                    { name: 'comment'; required: false; binding: 'uuid' },
+                ];
+                optional: [{ name: 'maybe'; required: false }];
+            }
+        }
+        ${source}
+    `;
+
+    const cursor = source.indexOf(marker);
+    source = source.replace(marker, '');
+
+    const compilerOptions: ts.CompilerOptions = {
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        strict: true,
+        lib: ['lib.esnext.d.ts'],
+        noEmit: true,
+    };
+
+    function fileExists(fileName: string) {
+        return fileName === fixtureFile || ts.sys.fileExists(fileName);
+    }
+    function readFile(fileName: string) {
+        return fileName === fixtureFile ? source : ts.sys.readFile(fileName);
+    }
+
+    const host: ts.LanguageServiceHost = {
+        getCompilationSettings: () => compilerOptions,
+        getCurrentDirectory: () => process.cwd(),
+        getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+        getScriptFileNames: () => [fixtureFile],
+        getScriptVersion: () => '0',
+        getScriptSnapshot: (fileName) => {
+            const contents = readFile(fileName);
+            return contents === undefined ? undefined : ts.ScriptSnapshot.fromString(contents);
+        },
+        fileExists,
+        readFile,
+        readDirectory: ts.sys.readDirectory,
+        directoryExists: ts.sys.directoryExists,
+        getDirectories: ts.sys.getDirectories,
+        resolveModuleNames: (moduleNames, containingFile) =>
+            moduleNames.map(
+                (moduleName) =>
+                    ts.resolveModuleName(moduleName, containingFile, compilerOptions, {
+                        fileExists,
+                        readFile,
+                        directoryExists: ts.sys.directoryExists,
+                        getCurrentDirectory: () => process.cwd(),
+                        getDirectories: ts.sys.getDirectories,
+                        realpath: ts.sys.realpath,
+                    }).resolvedModule,
+            ),
+    };
+
+    const service = ts.createLanguageService(host);
+    const completions =
+        service
+            .getCompletionsAtPosition(fixtureFile, cursor, {})
+            ?.entries.map((entry) => entry.name) ?? [];
+
+    service.dispose();
+
+    return new Set(completions);
+}
+
+describe('TypeScript completions', () => {
+    test('suggests route params when a required param is still missing', () => {
+        let completions = getCompletions(`
+            route('posts.comments.show', {
+                /*cursor*/
+            });
+        `);
+
+        expect(completions).toContain('post');
+        expect(completions).toContain('comment');
+        expect(completions).toContain('_query');
+    });
+
+    test('suggests remaining params after required params are provided', () => {
+        let completions = getCompletions(`
+            route('posts.comments.show', {
+                post: 1,
+                /*cursor*/
+            });
+        `);
+
+        expect(completions).toContain('comment');
+        expect(completions).toContain('_query');
+        expect(completions).not.toContain('post');
+    });
+
+    test('suggests optional params on all-optional routes', () => {
+        let completions = getCompletions(`
+            route('optional', {
+                /*cursor*/
+            });
+        `);
+
+        expect(completions).toContain('maybe');
+        expect(completions).toContain('_query');
+    });
+});

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType } from 'vitest';
+import { assertType, expectTypeOf } from 'vitest';
 import { Config, route, Router, RouteUrl } from '../../src/js';
 
 // Add generated routes to use for testing inside this file. In a real app these declarations
@@ -124,6 +124,14 @@ assertType<RouteUrl>(route('posts.comments.show', 'foo'));
 assertType<RouteUrl>('/posts/foo' as string);
 assertType<Router>(route(undefined, undefined, false));
 assertType<Router>(route(undefined, undefined, undefined, {} as Config));
+
+// Derived parameter and return types should include all valid shapes/overloads
+expectTypeOf<ReturnType<typeof route>>().toEqualTypeOf<RouteUrl | Router>();
+expectTypeOf<['posts.index']>().toExtend<Parameters<typeof route>>();
+expectTypeOf<['posts.comments.show', { post: 1 }]>().toExtend<Parameters<typeof route>>();
+expectTypeOf<[]>().toExtend<Parameters<typeof route>>();
+expectTypeOf<[undefined, undefined, false]>().toExtend<Parameters<typeof route>>();
+expectTypeOf<[undefined, undefined, undefined, Config]>().toExtend<Parameters<typeof route>>();
 
 // Uncomment to test strict route name checking - invalid route names in this file should error
 // declare module '../../src/js' {

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -136,7 +136,7 @@ assertType<Router>(route(undefined, undefined, undefined, {} as Config));
 assertType(
     // @ts-expect-error missing required 'post' parameter
     route('posts.comments.show', {
-        // Trigger completions here (add a new line and type 'p' or 'c') - should suggest 'post' and 'comment'
+        // Trigger completions here (⌃Space or add a new line and type 'p' or 'c') - should suggest 'post' and 'comment'
     }),
 );
 assertType(

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -126,3 +126,17 @@ assertType<Router>(route(undefined, undefined, undefined, {} as Config));
 //         strictRouteNames: true;
 //     }
 // }
+
+// https://github.com/tighten/ziggy/issues/803
+assertType(
+    // @ts-expect-error missing required 'post' parameter
+    route('posts.comments.show', {
+        // Trigger completions here (add a new line and type 'p' or 'c') - should suggest 'post' and 'comment' but doesn't
+    }),
+);
+assertType(
+    route('posts.comments.show', {
+        post: 1,
+        // Trigger completions here - now that 'post' (required) is provided, suggestions show 'comment' as expected
+    }),
+);

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -132,7 +132,7 @@ assertType<Router>(route(undefined, undefined, undefined, {} as Config));
 //     }
 // }
 
-// https://github.com/tighten/ziggy/issues/803 (now fixed, by defining config-only `route()` overload last)
+// Test Intellisense/autocomplete
 assertType(
     // @ts-expect-error missing required 'post' parameter
     route('posts.comments.show', {

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -112,6 +112,10 @@ assertType(route().current('posts.comments.show', 'foo'));
 assertType(route('optional', []));
 assertType(route('optional', ['foo']));
 
+// All-optional route with config
+assertType(route('optional', undefined, false));
+assertType(route('optional', undefined, undefined, {} as Config));
+
 // Test route function return types
 assertType<string>(route('optional', { maybe: 'foo' }));
 assertType<string>(route('optional', 'foo'));

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -118,6 +118,7 @@ assertType<string>(route('optional', 'foo'));
 assertType<RouteUrl>(route('posts.comments.show', 'foo'));
 // @ts-expect-error a plain string is not assignable to RouteUrl
 assertType<RouteUrl>('/posts/foo' as string);
+assertType<Router>(route(undefined, undefined, false));
 assertType<Router>(route(undefined, undefined, undefined, {} as Config));
 
 // Uncomment to test strict route name checking - invalid route names in this file should error

--- a/tests/js/route.test-d.ts
+++ b/tests/js/route.test-d.ts
@@ -127,11 +127,11 @@ assertType<Router>(route(undefined, undefined, undefined, {} as Config));
 //     }
 // }
 
-// https://github.com/tighten/ziggy/issues/803
+// https://github.com/tighten/ziggy/issues/803 (now fixed, by defining config-only `route()` overload last)
 assertType(
     // @ts-expect-error missing required 'post' parameter
     route('posts.comments.show', {
-        // Trigger completions here (add a new line and type 'p' or 'c') - should suggest 'post' and 'comment' but doesn't
+        // Trigger completions here (add a new line and type 'p' or 'c') - should suggest 'post' and 'comment'
     }),
 );
 assertType(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "ESNext",
         "moduleResolution": "Bundler",
-        "target": "ESNext"
+        "target": "ESNext",
+        "types": ["node"]
     },
     "exclude": ["vendor", "tests/fixtures"]
 }


### PR DESCRIPTION
This PR fixes #803, where route parameter names are not suggested/completed inside `route()` calls until all the route's required parameters are provided.

There are a few different pieces to this:

- The core fix was just moving the config-only `route(undefined, undefined, ...)` overloaded type definition so that's it's **defined last**. This is enough to make intellisense find the earlier overloads and autocomplete params from them.
- This stopped basic route _name_ autocomplete from working, so to fix that I added an additional overload at the beginning to match just a route name and no other arguments.
- When not in strict mode (`strict` and `strictNullChecks` missing from `tsconfig.json` or set to `false`), calling `route(undefined, ...)` _does_ match the earlier overloads, and incorrectly appears to return a `RouteUrl` instead of a `Router`. Changing the `name` parameters to `T & {}` fixes this, preventing `undefined` from matching those params. This is kinda ugly but improves compatibility and I'm confident the tests we have prove it works fine.
- Finally, I added an additional very broad overload at the end so that the derived parameter and return types of the `route` function match everything it actually allows at runtime, so that things like wrapper/helper functions around `route` can reference its types.

This PR also finally adds real intellisense/autocompletion tests! We spin up a full TypeScript language service, pass it some fixture code, and assert against what completions it says it will generate.