### PR TITLE
Create the directory for a custom types path if it doesn't exist

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -55,6 +55,8 @@ class CommandRouteGenerator extends Command
                 default => $this->option('types'),
             };
 
+            $filesystem->ensureDirectoryExists(dirname(base_path($typesPath)), recursive: true);
+
             $filesystem->put(base_path($typesPath), new $types($ziggy));
         }
 

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -163,6 +163,17 @@ test('generate dts file at custom path', function () {
     expect(base_path('resources/js/custom.d.ts'))->toBeFile();
 });
 
+test('generate dts file at custom path in a directory that does not exist', function () {
+    if (is_dir(base_path('resources/types'))) {
+        array_map(unlink(...), glob(base_path('resources/types/*')));
+        rmdir(base_path('resources/types'));
+    }
+
+    artisan('ziggy:generate --types-only --types=resources/types/ziggy.d.ts');
+
+    expect(base_path('resources/types/ziggy.d.ts'))->toBeFile();
+});
+
 test('generate dts file at path set in config', function () {
     config(['ziggy.output.types-path' => 'resources/js/types.d.ts']);
 


### PR DESCRIPTION
When a custom path is passed to `--types`, the declaration file is written without first ensuring its parent directory exists. Running `ziggy:generate` with a custom types path therefore fails if that directory isn't already there:

```bash
php artisan ziggy:generate --types-only --types=tmp/ziggy/nested/ziggy.d.ts
# file_put_contents(.../tmp/ziggy/nested/ziggy.d.ts): Failed to open stream: No such file or directory
```

`CommandRouteGenerator` already calls `ensureDirectoryExists()` for the main output path, but not for the custom types path that's written later. This adds the same call before writing the types file, so its directory is created when needed, just like for the main output.

Closes #883.
