### PR TITLE
Honor absolute paths passed to ziggy:generate

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -33,10 +33,10 @@ class CommandRouteGenerator extends Command
 
         $path = $this->argument('path') ?? config('ziggy.output.path', 'resources/js/ziggy.js');
 
-        if ($filesystem->isDirectory(base_path($path))) {
+        if ($filesystem->isDirectory($this->path($path))) {
             $path .= '/ziggy';
         } else {
-            $filesystem->ensureDirectoryExists(dirname(base_path($path)), recursive: true);
+            $filesystem->ensureDirectoryExists(dirname($this->path($path)), recursive: true);
         }
 
         $name = preg_replace('/(\.d)?\.ts$|\.js$/', '', $path);
@@ -44,7 +44,7 @@ class CommandRouteGenerator extends Command
         if (! $this->option('types-only')) {
             $output = config('ziggy.output.file', File::class);
 
-            $filesystem->put(base_path("{$name}.js"), new $output($ziggy));
+            $filesystem->put($this->path("{$name}.js"), new $output($ziggy));
         }
 
         if ($this->option('types') !== 'false' || $this->option('types-only')) {
@@ -55,11 +55,20 @@ class CommandRouteGenerator extends Command
                 default => $this->option('types'),
             };
 
-            $filesystem->ensureDirectoryExists(dirname(base_path($typesPath)), recursive: true);
+            $filesystem->ensureDirectoryExists(dirname($this->path($typesPath)), recursive: true);
 
-            $filesystem->put(base_path($typesPath), new $types($ziggy));
+            $filesystem->put($this->path($typesPath), new $types($ziggy));
         }
 
         $this->info('Files generated!');
+    }
+
+    private function path(string $path): string
+    {
+        $isAbsolute = str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || (strlen($path) > 1 && ctype_alpha($path[0]) && $path[1] === ':');
+
+        return $isAbsolute ? $path : base_path($path);
     }
 }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -138,6 +138,14 @@ test('generate file at path set in config', function () {
     expect(base_path('resources/js/custom.js'))->toBeFile();
 });
 
+test('generate file at absolute path', function () {
+    $path = sys_get_temp_dir() . '/' . uniqid() . '/ziggy.js';
+
+    artisan('ziggy:generate', ['path' => $path]);
+
+    expect($path)->toBeFile();
+});
+
 test('generate dts file', function () {
     Route::get('posts', fn () => '')->name('posts.index');
     Route::post('posts/{post}/comments', fn ($post, $comment) => '')->name('comments.store');


### PR DESCRIPTION
`ziggy:generate` wraps the output path in `base_path()` unconditionally, so passing an absolute path like `/tmp/ziggy.js` writes the file under the application root instead of where it was requested. This routes every path through a small helper that only prepends `base_path()` when the path is relative, leaving absolute paths untouched.

Reopens #891, closed after I accidentally deleted the fork. Same commit, no changes.

Closes #882.