### PR TITLE
Generate the types file when --types is passed as a boolean

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -51,7 +51,7 @@ class CommandRouteGenerator extends Command
             $types = config('ziggy.output.types', Types::class);
 
             $typesPath = match ($this->option('types')) {
-                'false', null => config('ziggy.output.types-path', "{$name}.d.ts"),
+                'false', '1', true, null => config('ziggy.output.types-path', "{$name}.d.ts"),
                 default => $this->option('types'),
             };
 

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -180,6 +180,13 @@ test('generate dts file at path set in config', function () {
     expect(base_path('resources/js/types.d.ts'))->toBeFile();
 });
 
+test('generate dts file when types option passed as boolean', function () {
+    artisan('ziggy:generate', ['--types' => true]);
+
+    expect(base_path('resources/js/ziggy.js'))->toBeFile();
+    expect(base_path('resources/js/ziggy.d.ts'))->toBeFile();
+});
+
 test('generate dts file without generating routes file', function () {
     artisan('ziggy:generate --types-only');
 


### PR DESCRIPTION
Passing `--types` as a boolean (e.g. `Artisan::call('ziggy:generate', ['--types' => true])`, which is the convention Laravel documents for boolean options) coerces the value to the string `"1"`, which then falls through the `match` in `CommandRouteGenerator` and gets used as the types file's path, so the declaration file is written to a file named `1` in the project root instead of at the default location. This adds the coerced boolean value to the arm that already handles `false`/`null`, so a boolean `--types` generates the types file at the default path as expected.

Reopens #892, closed after I accidentally deleted the fork. Same commit, no changes.

Closes #879.